### PR TITLE
Removed spare empty lines to make syntax of README.md files coherent

### DIFF
--- a/analysed-packages/busybox/version-1.35.0/README.md
+++ b/analysed-packages/busybox/version-1.35.0/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://busybox.net/downloads/busybox-1.35.0.tar.bz2
 
 ## Reviewers

--- a/analysed-packages/expat/version-2.5.0/README.md
+++ b/analysed-packages/expat/version-2.5.0/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://github.com/libexpat/libexpat/archive/refs/tags/R_2_5_0.tar.gz
 
 ## Reviewers

--- a/analysed-packages/ffmpeg/version-n5.1.1/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.1/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.1.tar.gz
 
 ## Reviewers

--- a/analysed-packages/ffmpeg/version-n5.1.2/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.2/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.2.tar.gz
 
 ## Reviewers

--- a/analysed-packages/gmp/version-6.2.1/README.md
+++ b/analysed-packages/gmp/version-6.2.1/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
 
 ## Reviewers

--- a/analysed-packages/libffi/version-3.4.0/README.md
+++ b/analysed-packages/libffi/version-3.4.0/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://github.com/libffi/libffi/archive/refs/tags/v3.4.0.tar.gz
 
 ## Reviewers

--- a/analysed-packages/libgpg-error/version-1.46/README.md
+++ b/analysed-packages/libgpg-error/version-1.46/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.46.tar.gz
 
 ## Reviewers

--- a/analysed-packages/libmicrohttpd/version-0.9.75/README.md
+++ b/analysed-packages/libmicrohttpd/version-0.9.75/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://github.com/Karlson2k/libmicrohttpd/archive/refs/tags/v0.9.75.tar.gz
 
 ## Reviewers

--- a/analysed-packages/lvgl/version-8.3.3/README.md
+++ b/analysed-packages/lvgl/version-8.3.3/README.md
@@ -1,8 +1,6 @@
 ## Download Location
 
-
 https://github.com/lvgl/lvgl/archive/refs/tags/v8.3.3.tar.gz
-
 
 ## Reviewers
 

--- a/analysed-packages/lz4/version-1.9.4/README.md
+++ b/analysed-packages/lz4/version-1.9.4/README.md
@@ -1,8 +1,6 @@
 ## Download Location
 
-
 https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz
-
 
 ## Reviewers
 

--- a/analysed-packages/nettle/version-3.8/README.md
+++ b/analysed-packages/nettle/version-3.8/README.md
@@ -1,6 +1,5 @@
 ## Download Location
 
-
 https://ftp.gnu.org/gnu/nettle/nettle-3.8.tar.gz
 
 ## Reviewers


### PR DESCRIPTION
This is a first step toward inclusion of package URLs.