### PR TITLE
Second attempt to add package URLs to README.md files

### DIFF
--- a/analysed-packages/Alpine/version-3.15/alpine-base-3.15.0/README.md
+++ b/analysed-packages/Alpine/version-3.15/alpine-base-3.15.0/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/alpine-base?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/alpine-base@3.15?download_url=https://git.alpinelinux.org/aports/tree/main/alpine-base?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/README.md
+++ b/analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/alpine-baselayout?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/alpine-baselayout@3.2.0?download_url=https://git.alpinelinux.org/aports/tree/main/alpine-baselayout?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/alpine-conf-3.13.0/README.md
+++ b/analysed-packages/Alpine/version-3.15/alpine-conf-3.13.0/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/alpine-conf?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/alpine-conf@3.13.0?download_url=https://git.alpinelinux.org/aports/tree/main/alpine-conf?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/alpine-keys-2.4/README.md
+++ b/analysed-packages/Alpine/version-3.15/alpine-keys-2.4/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/alpine-keys?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/alpine-keys@2.4?download_url=https://git.alpinelinux.org/aports/tree/main/alpine-keys?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/apk-tools-2.12.7/README.md
+++ b/analysed-packages/Alpine/version-3.15/apk-tools-2.12.7/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/apk-tools?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/apk-tools@2.12.7?download_url=https://git.alpinelinux.org/aports/tree/main/apk-tools?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/busybox-initscripts-version-4.0/README.md
+++ b/analysed-packages/Alpine/version-3.15/busybox-initscripts-version-4.0/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/busybox-initscripts?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/busybox-initscripts@3.15-stable?download_url=https://git.alpinelinux.org/aports/tree/main/busybox-initscripts?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/README.md
+++ b/analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/busybox?h=3.15-stable
 
-### busybox
+## Package URL (purl)
 
-https://busybox.net/downloads/busybox-1.34.1.tar.bz2
+pkg:generic/busybox@1.34.1?download_url=https://busybox.net/downloads/busybox-1.34.1.tar.bz2
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/README.md
+++ b/analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/ca-certificates?h=3.15-stable
 
-### ca-certificates
+## Package URL (purl)
 
-https://gitlab.alpinelinux.org/alpine/ca-certificates/-/archive/20211220/ca-certificates-20211220.tar.bz2
+pkg:generic/ca-certificates@20211220?download_url=https://gitlab.alpinelinux.org/alpine/ca-certificates/-/archive/20211220/ca-certificates-20211220.tar.bz2
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/ifupdown-ng-version-0.11.3/README.md
+++ b/analysed-packages/Alpine/version-3.15/ifupdown-ng-version-0.11.3/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/ifupdown-ng?h=3.15-stable
 
-### Ifupdown-ng
+## Package URL (purl)
 
-https://distfiles.dereferenced.org/ifupdown-ng/ifupdown-ng-0.11.3.tar.xz
+pkg:generic/ifupdown-ng@0.11.3?download_url=https://distfiles.dereferenced.org/ifupdown-ng/ifupdown-ng-0.11.3.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/libc-dev-version-0.7.2/README.md
+++ b/analysed-packages/Alpine/version-3.15/libc-dev-version-0.7.2/README.md
@@ -1,9 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/libc-dev?h=3.15-stable
 
+## Package URL (purl)
+
+pkg:generic/libc-dev@0.7.2?download_url=https://git.alpinelinux.org/aports/tree/main/libc-dev?h=3.15-stable
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/libretls-version-3.3.4/README.md
+++ b/analysed-packages/Alpine/version-3.15/libretls-version-3.3.4/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/libretls?h=3.15-stable
 
-### libretls
+## Package URL (purl)
 
-https://git.causal.agency/libretls/snapshot/libretls-3.3.4.tar.gz
+pkg:generic/libretls@3.3.4?download_url=https://git.causal.agency/libretls/snapshot/libretls-3.3.4.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/musl-version-1.2.2/README.md
+++ b/analysed-packages/Alpine/version-3.15/musl-version-1.2.2/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/musl?h=3.15-stable
 
-### Musl
+## Package URL (purl)
 
-https://git.musl-libc.org/cgit/musl/snapshot/1.2.2.tar.gz
+pkg:generic/musl@1.2.2?download_url=https://git.musl-libc.org/cgit/musl/snapshot/1.2.2.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/openSSL-version-1.1.1l/README.md
+++ b/analysed-packages/Alpine/version-3.15/openSSL-version-1.1.1l/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/openssl?h=3.15-stable
 
-### OpenSSL
+## Package URL (purl)
 
-https://www.openssl.org/source/openssl-1.1.1l.tar.gz
+pkg:generic/openssl@1.1.1l?download_url=https://www.openssl.org/source/openssl-1.1.1l.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/openrc-version-0.44.7/README.md
+++ b/analysed-packages/Alpine/version-3.15/openrc-version-0.44.7/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/openrc?h=3.15-stable
 
-### OpenRC
+## Package URL (purl)
 
-https://github.com/OpenRC/openrc/archive/refs/tags/0.44.7.tar.gz
+pkg:generic/openrc@0.44.7?download_url=https://github.com/OpenRC/openrc/archive/refs/tags/0.44.7.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/README.md
+++ b/analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/pax-utils?h=3.15-stable
 
-### Pax-utils
+## Package URL (purl)
 
-https://dev.gentoo.org/~sam/distfiles/pax-utils-1.3.3.tar.xz
+pkg:generic/pax-utils@1.3.3?download_url=https://dev.gentoo.org/~sam/distfiles/pax-utils-1.3.3.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/Alpine/version-3.15/zlib-version-1.2.11/README.md
+++ b/analysed-packages/Alpine/version-3.15/zlib-version-1.2.11/README.md
@@ -1,12 +1,10 @@
 ## Download Location
 
-### Alpine
-
 https://git.alpinelinux.org/aports/tree/main/zlib?h=3.15-stable
 
-### zlib
+## Package URL (purl)
 
-https://zlib.net/zlib-1.2.12.tar.gz
+pkg:generic/zlib@1.2.12?download_url=https://zlib.net/zlib-1.2.12.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-1.1.1q/README.md
+++ b/analysed-packages/OpenSSL/version-1.1.1q/README.md
@@ -4,7 +4,7 @@ https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1q.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/openssl/OpenSSL@1.1.1q
+pkg:github/openssl/openssl@1.1.1q
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-1.1.1q/README.md
+++ b/analysed-packages/OpenSSL/version-1.1.1q/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1q.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/openssl/OpenSSL@1.1.1q
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/OpenSSL/version-1.1.1s/README.md
+++ b/analysed-packages/OpenSSL/version-1.1.1s/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1s.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/openssl/OpenSSL@1.1.1s
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/OpenSSL/version-1.1.1s/README.md
+++ b/analysed-packages/OpenSSL/version-1.1.1s/README.md
@@ -4,7 +4,7 @@ https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1s.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/openssl/OpenSSL@1.1.1s
+pkg:github/openssl/openssl@1.1.1s
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-3.0.3/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.3/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.3.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/openssl/OpenSSL@3.0.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/OpenSSL/version-3.0.3/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.3/README.md
@@ -4,7 +4,7 @@ https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.3.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/openssl/OpenSSL@3.0.3
+pkg:github/openssl/openssl@3.0.3
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-3.0.5/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.5/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.5.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/openssl/OpenSSL@3.0.5
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/OpenSSL/version-3.0.5/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.5/README.md
@@ -4,7 +4,7 @@ https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.5.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/openssl/OpenSSL@3.0.5
+pkg:github/openssl/openssl@3.0.5
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-3.0.7/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.7/README.md
@@ -4,7 +4,7 @@ https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.7.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/openssl/OpenSSL@3.0.7
+pkg:github/openssl/openssl@3.0.7
 
 ## Reviewers
 

--- a/analysed-packages/OpenSSL/version-3.0.7/README.md
+++ b/analysed-packages/OpenSSL/version-3.0.7/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.7.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/openssl/OpenSSL@3.0.7
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/acl/version-2.2.53/README.md
+++ b/analysed-packages/acl/version-2.2.53/README.md
@@ -2,6 +2,10 @@
 
 https://download-mirror.savannah.gnu.org/releases/acl/acl-2.2.53.tar.gz
 
+## Package URL (purl)
+
+pkg:none/download-mirror.savannah.gnu.org/releases/acl@2.2.53
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/acl/version-2.2.53/README.md
+++ b/analysed-packages/acl/version-2.2.53/README.md
@@ -4,7 +4,7 @@ https://download-mirror.savannah.gnu.org/releases/acl/acl-2.2.53.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/download-mirror.savannah.gnu.org/releases/acl@2.2.53
+pkg:generic/acl@2.2.53?download_url=https://download-mirror.savannah.gnu.org/releases/acl/acl-2.2.53.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/acl/version-2.3.1/README.md
+++ b/analysed-packages/acl/version-2.3.1/README.md
@@ -4,7 +4,7 @@ https://download-mirror.savannah.gnu.org/releases/acl/acl-2.3.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/download-mirror.savannah.gnu.org/releases/acl@2.3.1
+pkg:generic/acl@2.3.1?download_url=https://download-mirror.savannah.gnu.org/releases/acl/acl-2.3.1.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/acl/version-2.3.1/README.md
+++ b/analysed-packages/acl/version-2.3.1/README.md
@@ -2,6 +2,10 @@
 
 https://download-mirror.savannah.gnu.org/releases/acl/acl-2.3.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/download-mirror.savannah.gnu.org/releases/acl@2.3.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/ajv/version-8.10.0/README.md
+++ b/analysed-packages/ajv/version-8.10.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/ajv-validator/ajv/archive/refs/tags/v8.10.0.zip
 
+## Package URL (purl)
+
+pkg:none/github.com/ajv-validator/ajv@8.10.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/ajv/version-8.10.0/README.md
+++ b/analysed-packages/ajv/version-8.10.0/README.md
@@ -4,7 +4,7 @@ https://github.com/ajv-validator/ajv/archive/refs/tags/v8.10.0.zip
 
 ## Package URL (purl)
 
-pkg:none/github.com/ajv-validator/ajv@8.10.0
+pkg:github/ajv-validator/ajv@8.10.0
 
 ## Reviewers
 

--- a/analysed-packages/allwpilib/version-2022.4.1/README.md
+++ b/analysed-packages/allwpilib/version-2022.4.1/README.md
@@ -4,7 +4,7 @@ https://github.com/wpilibsuite/allwpilib/archive/refs/tags/v2022.4.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/wpilibsuite/allwpilib@2022.4.1
+pkg:github/wpilibsuite/allwpilib@2022.4.1
 
 ## Reviewers
 

--- a/analysed-packages/allwpilib/version-2022.4.1/README.md
+++ b/analysed-packages/allwpilib/version-2022.4.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/wpilibsuite/allwpilib/archive/refs/tags/v2022.4.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/wpilibsuite/allwpilib@2022.4.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/attr/version-2.4.48/README.md
+++ b/analysed-packages/attr/version-2.4.48/README.md
@@ -2,6 +2,10 @@
 
 http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.4.48.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.cc.uoc.gr/mirrors/attr@2.4.48
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/attr/version-2.4.48/README.md
+++ b/analysed-packages/attr/version-2.4.48/README.md
@@ -4,7 +4,7 @@ http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.4.48.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.cc.uoc.gr/mirrors/attr@2.4.48
+pkg:generic/attr@2.4.48?download_url=http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.4.48.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/attr/version-2.5.1/README.md
+++ b/analysed-packages/attr/version-2.5.1/README.md
@@ -4,7 +4,7 @@ http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.5.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.cc.uoc.gr/mirrors/attr@2.5.1
+pkg:generic/attr@2.5.1?download_url=http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.5.1.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/attr/version-2.5.1/README.md
+++ b/analysed-packages/attr/version-2.5.1/README.md
@@ -2,6 +2,10 @@
 
 http://ftp.cc.uoc.gr/mirrors/nongnu.org/attr/attr-2.5.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.cc.uoc.gr/mirrors/attr@2.5.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/audit/version-3.0.8/README.md
+++ b/analysed-packages/audit/version-3.0.8/README.md
@@ -4,7 +4,7 @@ https://people.redhat.com/sgrubb/audit/audit-3.0.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/people.redhat.com/sgrubb/audit@3.0.8
+pkg:generic/audit@3.0.8?download_url=https://people.redhat.com/sgrubb/audit/audit-3.0.8.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/audit/version-3.0.8/README.md
+++ b/analysed-packages/audit/version-3.0.8/README.md
@@ -2,6 +2,10 @@
 
 https://people.redhat.com/sgrubb/audit/audit-3.0.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/people.redhat.com/sgrubb/audit@3.0.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bash/version-5.1.16/README.md
+++ b/analysed-packages/bash/version-5.1.16/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/bash@5.1.16
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bash/version-5.1.16/README.md
+++ b/analysed-packages/bash/version-5.1.16/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/bash@5.1.16
+pkg:generic/bash@5.1.16?download_url=https://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/behaviorTree.CPP/version-3.8.0/README.md
+++ b/analysed-packages/behaviorTree.CPP/version-3.8.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/3.8.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/BehaviorTree/behaviorTree.CPP@3.8.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/behaviorTree.CPP/version-3.8.0/README.md
+++ b/analysed-packages/behaviorTree.CPP/version-3.8.0/README.md
@@ -4,7 +4,7 @@ https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/3.8.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/BehaviorTree/behaviorTree.CPP@3.8.0
+pkg:github/BehaviorTree/behaviorTree.CPP@3.8.0
 
 ## Reviewers
 

--- a/analysed-packages/bionic/version-cts-12.1_r2/README.md
+++ b/analysed-packages/bionic/version-cts-12.1_r2/README.md
@@ -4,7 +4,7 @@ https://github.com/aosp-mirror/platform_bionic/archive/refs/tags/android-cts-12.
 
 ## Package URL (purl)
 
-pkg:none/github.com/aosp-mirror/bionic@cts-12.1_r2
+pkg:github/aosp-mirror/bionic@cts-12.1_r2
 
 ## Reviewers
 

--- a/analysed-packages/bionic/version-cts-12.1_r2/README.md
+++ b/analysed-packages/bionic/version-cts-12.1_r2/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/aosp-mirror/platform_bionic/archive/refs/tags/android-cts-12.1_r2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/aosp-mirror/bionic@cts-12.1_r2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bootstrap/version-4.0.0/README.md
+++ b/analysed-packages/bootstrap/version-4.0.0/README.md
@@ -4,7 +4,7 @@ https://github.com/twbs/bootstrap/archive/refs/tags/v4.0.0.zip
 
 ## Package URL (purl)
 
-pkg:none/github.com/twbs/bootstrap@4.0.0
+pkg:github/twbs/bootstrap@4.0.0
 
 ## Reviewers
 

--- a/analysed-packages/bootstrap/version-4.0.0/README.md
+++ b/analysed-packages/bootstrap/version-4.0.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/twbs/bootstrap/archive/refs/tags/v4.0.0.zip
 
+## Package URL (purl)
+
+pkg:none/github.com/twbs/bootstrap@4.0.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bootstrap/version-5.1.3/README.md
+++ b/analysed-packages/bootstrap/version-5.1.3/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/twbs/bootstrap/archive/refs/tags/v5.1.3.zip
 
+## Package URL (purl)
+
+pkg:none/github.com/twbs/bootstrap@5.1.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bootstrap/version-5.1.3/README.md
+++ b/analysed-packages/bootstrap/version-5.1.3/README.md
@@ -4,7 +4,7 @@ https://github.com/twbs/bootstrap/archive/refs/tags/v5.1.3.zip
 
 ## Package URL (purl)
 
-pkg:none/github.com/twbs/bootstrap@5.1.3
+pkg:github/twbs/bootstrap@5.1.3
 
 ## Reviewers
 

--- a/analysed-packages/busybox/version-1.35.0/README.md
+++ b/analysed-packages/busybox/version-1.35.0/README.md
@@ -4,7 +4,7 @@ https://busybox.net/downloads/busybox-1.35.0.tar.bz2
 
 ## Package URL (purl)
 
-pkg:none/busybox.net/downloads/busybox@1.35.0
+pkg:generic/busybox@1.35.0?download_url=https://busybox.net/downloads/busybox-1.35.0.tar.bz2
 
 ## Reviewers
 

--- a/analysed-packages/busybox/version-1.35.0/README.md
+++ b/analysed-packages/busybox/version-1.35.0/README.md
@@ -2,6 +2,10 @@
 
 https://busybox.net/downloads/busybox-1.35.0.tar.bz2
 
+## Package URL (purl)
+
+pkg:none/busybox.net/downloads/busybox@1.35.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bzip2/version-1.0.8/README.md
+++ b/analysed-packages/bzip2/version-1.0.8/README.md
@@ -2,6 +2,10 @@
 
 https://gitlab.com/bzip2/bzip2/-/archive/bzip2-1.0.8/bzip2-bzip2-1.0.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/gitlab.com/bzip2/bzip2@1.0.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/bzip2/version-1.0.8/README.md
+++ b/analysed-packages/bzip2/version-1.0.8/README.md
@@ -4,7 +4,7 @@ https://gitlab.com/bzip2/bzip2/-/archive/bzip2-1.0.8/bzip2-bzip2-1.0.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/gitlab.com/bzip2/bzip2@1.0.8
+pkg:gitlab/bzip2/bzip2@1.0.8
 
 ## Reviewers
 

--- a/analysed-packages/checkpolicy/version-3.4/README.md
+++ b/analysed-packages/checkpolicy/version-3.4/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/SELinuxProject/checkpolicy@3.4
 
 ## Reviewers
 

--- a/analysed-packages/checkpolicy/version-3.4/README.md
+++ b/analysed-packages/checkpolicy/version-3.4/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.4.tar.
 
 ## Package URL (purl)
 
-pkg:none/github.com/SELinuxProject/checkpolicy@3.4
+pkg:github/SELinuxProject/checkpolicy@3.4
 
 ## Reviewers
 

--- a/analysed-packages/coreboot/version-4.16/README.md
+++ b/analysed-packages/coreboot/version-4.16/README.md
@@ -2,6 +2,10 @@
 
 https://coreboot.org/releases/coreboot-4.16.tar.xz
 
+## Package URL (purl)
+
+pkg:none/coreboot.org/releases/coreboot@4.16
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/coreboot/version-4.16/README.md
+++ b/analysed-packages/coreboot/version-4.16/README.md
@@ -4,7 +4,7 @@ https://coreboot.org/releases/coreboot-4.16.tar.xz
 
 ## Package URL (purl)
 
-pkg:none/coreboot.org/releases/coreboot@4.16
+pkg:generic/coreboot@4.16?download_url=https://coreboot.org/releases/coreboot-4.16.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/coreutils/version-9.1/README.md
+++ b/analysed-packages/coreutils/version-9.1/README.md
@@ -4,7 +4,7 @@ https://github.com/coreutils/coreutils/archive/refs/tags/v9.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/coreutils/coreutils@9.1
+pkg:github/coreutils/coreutils@9.1
 
 ## Reviewers
 

--- a/analysed-packages/coreutils/version-9.1/README.md
+++ b/analysed-packages/coreutils/version-9.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/coreutils/coreutils/archive/refs/tags/v9.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/coreutils/coreutils@9.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/cpio/version-2.13/README.md
+++ b/analysed-packages/cpio/version-2.13/README.md
@@ -4,7 +4,7 @@ https://git.savannah.gnu.org/cgit/cpio.git/snapshot/cpio-release_2_13.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/git.savannah.gnu.org/cgit/cpio@2.13
+pkg:generic/cpio@2.13?download_url=https://git.savannah.gnu.org/cgit/cpio.git/snapshot/cpio-release_2_13.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/cpio/version-2.13/README.md
+++ b/analysed-packages/cpio/version-2.13/README.md
@@ -2,6 +2,10 @@
 
 https://git.savannah.gnu.org/cgit/cpio.git/snapshot/cpio-release_2_13.tar.gz
 
+## Package URL (purl)
+
+pkg:none/git.savannah.gnu.org/cgit/cpio@2.13
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/curl/version-7.86.0/README.md
+++ b/analysed-packages/curl/version-7.86.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/curl/curl/archive/refs/tags/curl-7_86_0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/curl/curl@7.86.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/curl/version-7.86.0/README.md
+++ b/analysed-packages/curl/version-7.86.0/README.md
@@ -4,7 +4,7 @@ https://github.com/curl/curl/archive/refs/tags/curl-7_86_0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/curl/curl@7.86.0
+pkg:github/curl/curl@7.86.0
 
 ## Reviewers
 

--- a/analysed-packages/dart-lang/args/version-2.3.0/README.md
+++ b/analysed-packages/dart-lang/args/version-2.3.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/dart-lang/args/archive/refs/tags/2.3.0.zip
 
+## Package URL (purl)
+
+pkg:github/dart-lang/args@2.3.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/dart-lang/characters/version-1.2.0/README.md
+++ b/analysed-packages/dart-lang/characters/version-1.2.0/README.md
@@ -1,6 +1,10 @@
 ## Download Location
 
-Not known
+https://github.com/dart-lang/characters/archive/refs/tags/1.2.0.zip
+
+## Package URL (purl)
+
+pkg:github/dart-lang/characters@1.2.0
 
 ## Remarks
 

--- a/analysed-packages/dart-lang/clock/version-1.1.0/README.md
+++ b/analysed-packages/dart-lang/clock/version-1.1.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/dart-lang/clock/archive/refs/tags/1.1.0.zip
 
+## Package URL (purl)
+
+pkg:github/dart-lang/clock@1.1.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/dart-lang/html/version-0.15.0/README.md
+++ b/analysed-packages/dart-lang/html/version-0.15.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/dart-lang/html/archive/refs/tags/0.15.0.zip
 
+## Package URL (purl)
+
+pkg:github/dart-lang/html@0.15.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/dash/version-0.5.11.4/README.md
+++ b/analysed-packages/dash/version-0.5.11.4/README.md
@@ -4,7 +4,7 @@ https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.11.5.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/git.kernel.org/pub/dash@0.5.11.4
+pkg:generic/dash@0.5.11.4?download_url=https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.11.5.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/dash/version-0.5.11.4/README.md
+++ b/analysed-packages/dash/version-0.5.11.4/README.md
@@ -2,6 +2,10 @@
 
 https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.11.5.tar.gz
 
+## Package URL (purl)
+
+pkg:none/git.kernel.org/pub/dash@0.5.11.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/diffutils/version-3.5/README.md
+++ b/analysed-packages/diffutils/version-3.5/README.md
@@ -4,7 +4,7 @@ https://github.com/Distrotech/diffutils/archive/refs/tags/v3.5.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/Distrotech/diffutils@3.5
+pkg:github/Distrotech/diffutils@3.5
 
 ## Reviewers
 

--- a/analysed-packages/diffutils/version-3.5/README.md
+++ b/analysed-packages/diffutils/version-3.5/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Distrotech/diffutils/archive/refs/tags/v3.5.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/Distrotech/diffutils@3.5
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/efibootguard/version-0.11/README.md
+++ b/analysed-packages/efibootguard/version-0.11/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/siemens/efibootguard/archive/refs/tags/v0.11.zip
 
+## Package URL (purl)
+
+pkg:none/github.com/siemens/efibootguard@0.11
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/efibootguard/version-0.11/README.md
+++ b/analysed-packages/efibootguard/version-0.11/README.md
@@ -4,7 +4,7 @@ https://github.com/siemens/efibootguard/archive/refs/tags/v0.11.zip
 
 ## Package URL (purl)
 
-pkg:none/github.com/siemens/efibootguard@0.11
+pkg:github/siemens/efibootguard@0.11
 
 ## Reviewers
 

--- a/analysed-packages/expat/version-2.5.0/README.md
+++ b/analysed-packages/expat/version-2.5.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/libexpat/libexpat/archive/refs/tags/R_2_5_0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/libexpat/expat@2.5.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/expat/version-2.5.0/README.md
+++ b/analysed-packages/expat/version-2.5.0/README.md
@@ -4,7 +4,7 @@ https://github.com/libexpat/libexpat/archive/refs/tags/R_2_5_0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/libexpat/expat@2.5.0
+pkg:github/libexpat/expat@2.5.0
 
 ## Reviewers
 

--- a/analysed-packages/ffmpeg/version-n5.1.1/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/FFmpeg/ffmpeg@n5.1.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/ffmpeg/version-n5.1.1/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.1/README.md
@@ -4,7 +4,7 @@ https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/FFmpeg/ffmpeg@n5.1.1
+pkg:github/ffmpeg/ffmpeg@n5.1.1
 
 ## Reviewers
 

--- a/analysed-packages/ffmpeg/version-n5.1.2/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.2/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/FFmpeg/ffmpeg@n5.1.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/ffmpeg/version-n5.1.2/README.md
+++ b/analysed-packages/ffmpeg/version-n5.1.2/README.md
@@ -4,7 +4,7 @@ https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n5.1.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/FFmpeg/ffmpeg@n5.1.2
+pkg:github/ffmpeg/ffmpeg@n5.1.2
 
 ## Reviewers
 

--- a/analysed-packages/findutils/version-4.8.0/README.md
+++ b/analysed-packages/findutils/version-4.8.0/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
 
 ## Package URL (purl)
 
-pkg:generci/findutils@4.8.0?download_url=https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
+pkg:generic/findutils@4.8.0?download_url=https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/findutils/version-4.8.0/README.md
+++ b/analysed-packages/findutils/version-4.8.0/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/findutils@4.8.0
+pkg:generci/findutils@4.8.0?download_url=https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/findutils/version-4.8.0/README.md
+++ b/analysed-packages/findutils/version-4.8.0/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/findutils/findutils-4.8.0.tar.xz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/findutils@4.8.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/flutter/version-3.3.8/README.md
+++ b/analysed-packages/flutter/version-3.3.8/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/flutter/flutter/archive/refs/tags/3.3.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/flutter/flutter@3.3.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/flutter/version-3.3.8/README.md
+++ b/analysed-packages/flutter/version-3.3.8/README.md
@@ -4,7 +4,7 @@ https://github.com/flutter/flutter/archive/refs/tags/3.3.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/flutter/flutter@3.3.8
+pkg:github/flutter/flutter@3.3.8
 
 ## Reviewers
 

--- a/analysed-packages/gmp/version-6.2.1/README.md
+++ b/analysed-packages/gmp/version-6.2.1/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/gmp@6.2.1
+pkg:generic/gmp@6.2.1?download_url=https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
 
 ## Reviewers
 

--- a/analysed-packages/gmp/version-6.2.1/README.md
+++ b/analysed-packages/gmp/version-6.2.1/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/gmp@6.2.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/gnutls/version-3.7.8/README.md
+++ b/analysed-packages/gnutls/version-3.7.8/README.md
@@ -4,7 +4,7 @@ https://gitlab.com/gnutls/gnutls/-/archive/3.7.8/gnutls-3.7.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/gitlab.com/gnutls/gnutls@3.7.8
+pkg:gitlab/gnutls/gnutls@3.7.8
 
 ## Reviewers
 

--- a/analysed-packages/gnutls/version-3.7.8/README.md
+++ b/analysed-packages/gnutls/version-3.7.8/README.md
@@ -2,6 +2,10 @@
 
 https://gitlab.com/gnutls/gnutls/-/archive/3.7.8/gnutls-3.7.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/gitlab.com/gnutls/gnutls@3.7.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/grep/version-3.6/README.md
+++ b/analysed-packages/grep/version-3.6/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/grep/grep-3.6.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/grep@3.6
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/grep/version-3.6/README.md
+++ b/analysed-packages/grep/version-3.6/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/grep/grep-3.6.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/grep@3.6
+pkg:generic/grep@3.6?download_url=https://ftp.gnu.org/gnu/grep/grep-3.6.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/grub2/version-2.06/README.md
+++ b/analysed-packages/grub2/version-2.06/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/grub/grub-2.06.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/grub2@2.06
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/grub2/version-2.06/README.md
+++ b/analysed-packages/grub2/version-2.06/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/grub/grub-2.06.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/grub2@2.06
+pkg:generic/grub2@2.06?download_url=https://ftp.gnu.org/gnu/grub/grub-2.06.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/gzip/version-1.12/README.md
+++ b/analysed-packages/gzip/version-1.12/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/gzip@1.12
+pkg:generic/gzip@1.12@download_url=https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/gzip/version-1.12/README.md
+++ b/analysed-packages/gzip/version-1.12/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/gzip@1.12
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/hammerjs/version-2.0.8/README.md
+++ b/analysed-packages/hammerjs/version-2.0.8/README.md
@@ -4,7 +4,7 @@ https://github.com/hammerjs/hammer.js/archive/refs/tags/v2.0.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/hammerjs/hammerjs@2.0.8
+pkg:github/hammerjs/hammerjs@2.0.8
 
 ## Reviewers
 

--- a/analysed-packages/hammerjs/version-2.0.8/README.md
+++ b/analysed-packages/hammerjs/version-2.0.8/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/hammerjs/hammer.js/archive/refs/tags/v2.0.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/hammerjs/hammerjs@2.0.8
 
 ## Reviewers
 

--- a/analysed-packages/hiawatha/version-11.2/README.md
+++ b/analysed-packages/hiawatha/version-11.2/README.md
@@ -2,6 +2,9 @@
 
 https://www.hiawatha-webserver.org/files/hiawatha-11.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/www.hiawatha-webserver.org/files/hiawatha@11.2
 
 ## Reviewers
 

--- a/analysed-packages/hiawatha/version-11.2/README.md
+++ b/analysed-packages/hiawatha/version-11.2/README.md
@@ -4,7 +4,7 @@ https://www.hiawatha-webserver.org/files/hiawatha-11.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/www.hiawatha-webserver.org/files/hiawatha@11.2
+pkg:generic/hiawatha@11.2?download_url=https://www.hiawatha-webserver.org/files/hiawatha-11.2.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/iceoryx/version-2.0.2/README.md
+++ b/analysed-packages/iceoryx/version-2.0.2/README.md
@@ -4,7 +4,7 @@ https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/eclipse-iceoryx/iceoryx@2.0.2
+pkg:github/eclipse-iceoryx/iceoryx@2.0.2
 
 ## Reviewers
 

--- a/analysed-packages/iceoryx/version-2.0.2/README.md
+++ b/analysed-packages/iceoryx/version-2.0.2/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/eclipse-iceoryx/iceoryx@2.0.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/jpeg/version-v9e/README.md
+++ b/analysed-packages/jpeg/version-v9e/README.md
@@ -2,6 +2,10 @@
 
 https://www.ijg.org/files/jpegsrc.v9e.tar.gz
 
+## Package URL (purl)
+
+pkg:none/www.ijg.org/files/jpeg@v9e
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/jpeg/version-v9e/README.md
+++ b/analysed-packages/jpeg/version-v9e/README.md
@@ -4,7 +4,7 @@ https://www.ijg.org/files/jpegsrc.v9e.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/www.ijg.org/files/jpeg@v9e
+pkg:generic/jpeg@9e?download_url=https://www.ijg.org/files/jpegsrc.v9e.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/jquery/version-1.9.1/README.md
+++ b/analysed-packages/jquery/version-1.9.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/jquery/jquery/archive/refs/tags/1.9.1.zip
 
+## Package URL (purl)
+
+pkg:none/github.com/jquery/jquery@1.9.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/jquery/version-1.9.1/README.md
+++ b/analysed-packages/jquery/version-1.9.1/README.md
@@ -4,7 +4,7 @@ https://github.com/jquery/jquery/archive/refs/tags/1.9.1.zip
 
 ## Package URL (purl)
 
-pkg:none/github.com/jquery/jquery@1.9.1
+pkg:github/jquery/jquery@1.9.1
 
 ## Reviewers
 

--- a/analysed-packages/keyutils/version-1.6.1/README.md
+++ b/analysed-packages/keyutils/version-1.6.1/README.md
@@ -2,6 +2,10 @@
 
 https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2
 
+## Package URL (purl)
+
+pkg:none/people.redhat.com/~dhowells/keyutils@1.6.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/keyutils/version-1.6.1/README.md
+++ b/analysed-packages/keyutils/version-1.6.1/README.md
@@ -4,7 +4,7 @@ https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2
 
 ## Package URL (purl)
 
-pkg:none/people.redhat.com/~dhowells/keyutils@1.6.1
+pkg:generic/keyutils@1.6.1?download_url=https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2
 
 ## Reviewers
 

--- a/analysed-packages/libcap-ng/version-0.8.3/README.md
+++ b/analysed-packages/libcap-ng/version-0.8.3/README.md
@@ -4,7 +4,7 @@ https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v0.8.3.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/stevegrubb/libcap-ng@0.8.3
+pkg:github/stevegrubb/libcap-ng@0.8.3
 
 ## Reviewers
 

--- a/analysed-packages/libcap-ng/version-0.8.3/README.md
+++ b/analysed-packages/libcap-ng/version-0.8.3/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v0.8.3.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/stevegrubb/libcap-ng@0.8.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libffi/version-3.4.0/README.md
+++ b/analysed-packages/libffi/version-3.4.0/README.md
@@ -4,7 +4,7 @@ https://github.com/libffi/libffi/archive/refs/tags/v3.4.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/libffi/libffi@3.4.0
+pkg:github/libffi/libffi@3.4.0
 
 ## Reviewers
 

--- a/analysed-packages/libffi/version-3.4.0/README.md
+++ b/analysed-packages/libffi/version-3.4.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/libffi/libffi/archive/refs/tags/v3.4.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/libffi/libffi@3.4.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libgpg-error/version-1.46/README.md
+++ b/analysed-packages/libgpg-error/version-1.46/README.md
@@ -2,6 +2,10 @@
 
 https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.46.tar.gz
 
+## Package URL (purl)
+
+pkg:none/gnupg.org/ftp/libgpg-error@1.46
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libgpg-error/version-1.46/README.md
+++ b/analysed-packages/libgpg-error/version-1.46/README.md
@@ -4,7 +4,7 @@ https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.46.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/gnupg.org/ftp/libgpg-error@1.46
+pkg:generic/libgpg-error@1.46?download_url=https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.46.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/libmicrohttpd/version-0.9.75/README.md
+++ b/analysed-packages/libmicrohttpd/version-0.9.75/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Karlson2k/libmicrohttpd/archive/refs/tags/v0.9.75.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/Karlson2k/libmicrohttpd@0.9.75
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libmicrohttpd/version-0.9.75/README.md
+++ b/analysed-packages/libmicrohttpd/version-0.9.75/README.md
@@ -4,7 +4,7 @@ https://github.com/Karlson2k/libmicrohttpd/archive/refs/tags/v0.9.75.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/Karlson2k/libmicrohttpd@0.9.75
+pkg:github/Karlson2k/libmicrohttpd@0.9.75
 
 ## Reviewers
 

--- a/analysed-packages/libnsl/version-2.0.0/README.md
+++ b/analysed-packages/libnsl/version-2.0.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/thkukuk/libnsl/archive/refs/tags/v2.0.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/thkukuk/libnsl@2.0.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libnsl/version-2.0.0/README.md
+++ b/analysed-packages/libnsl/version-2.0.0/README.md
@@ -4,7 +4,7 @@ https://github.com/thkukuk/libnsl/archive/refs/tags/v2.0.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/thkukuk/libnsl@2.0.0
+pkg:github/thkukuk/libnsl@2.0.0
 
 ## Reviewers
 

--- a/analysed-packages/libpng/version-1.6.38/README.md
+++ b/analysed-packages/libpng/version-1.6.38/README.md
@@ -4,7 +4,7 @@ https://github.com/glennrp/libpng/archive/refs/tags/v1.6.38.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/glennrp/libpng@1.6.38
+pkg:github/glennrp/libpng@1.6.38
 
 ## Reviewers
 

--- a/analysed-packages/libpng/version-1.6.38/README.md
+++ b/analysed-packages/libpng/version-1.6.38/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/glennrp/libpng/archive/refs/tags/v1.6.38.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/glennrp/libpng@1.6.38
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libseccomp/version-2.5.1/README.md
+++ b/analysed-packages/libseccomp/version-2.5.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/seccomp/libseccomp/archive/refs/tags/v2.5.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/seccomp/libseccomp@2.5.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libseccomp/version-2.5.1/README.md
+++ b/analysed-packages/libseccomp/version-2.5.1/README.md
@@ -4,7 +4,7 @@ https://github.com/seccomp/libseccomp/archive/refs/tags/v2.5.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/seccomp/libseccomp@2.5.1
+pkg:github/seccomp/libseccomp@2.5.1
 
 ## Reviewers
 

--- a/analysed-packages/libselinux/version-3.4/README.md
+++ b/analysed-packages/libselinux/version-3.4/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/SELinuxProject/selinux/archive/refs/tags/libselinux-3.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/SELinuxProject/libselinux@3.4
 
 ## Reviewers
 

--- a/analysed-packages/libselinux/version-3.4/README.md
+++ b/analysed-packages/libselinux/version-3.4/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/libselinux-3.4.tar.g
 
 ## Package URL (purl)
 
-pkg:none/github.com/SELinuxProject/libselinux@3.4
+pkg:github/SELinuxProject/selinux/libselinux@3.4
 
 ## Reviewers
 

--- a/analysed-packages/libsemanage/version-3.4/README.md
+++ b/analysed-packages/libsemanage/version-3.4/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/SELinuxProject/selinux/archive/refs/tags/libsemanage-3.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/SELinuxProject/libsemanage@3.4
 
 ## Reviewers
 

--- a/analysed-packages/libsemanage/version-3.4/README.md
+++ b/analysed-packages/libsemanage/version-3.4/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/libsemanage-3.4.tar.
 
 ## Package URL (purl)
 
-pkg:none/github.com/SELinuxProject/libsemanage@3.4
+pkg:github/SELinuxProject/selinux/libsemanage@3.4
 
 ## Reviewers
 

--- a/analysed-packages/libsepol/version-3.4/README.md
+++ b/analysed-packages/libsepol/version-3.4/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/libsepol-3.4.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/SELinuxProject/libsepol@3.4
+pkg:github/SELinuxProject/selinux/libsepol@3.4
 
 ## Reviewers
 

--- a/analysed-packages/libsepol/version-3.4/README.md
+++ b/analysed-packages/libsepol/version-3.4/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/SELinuxProject/selinux/archive/refs/tags/libsepol-3.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/SELinuxProject/libsepol@3.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libtirpc/version-1.3.2/README.md
+++ b/analysed-packages/libtirpc/version-1.3.2/README.md
@@ -4,7 +4,7 @@ https://sourceforge.net/projects/libtirpc/files/libtirpc/1.3.2/libtirpc-1.3.2.ta
 
 ## Package URL (purl)
 
-pkg:none/sourceforge.net/projects/libtirpc@1.3.2
+pkg:generic/libtirpc@1.3.2?download_url=https://sourceforge.net/projects/libtirpc/files/libtirpc/1.3.2/libtirpc-1.3.2.tar.bz2/download
 
 ## Reviewers
 

--- a/analysed-packages/libtirpc/version-1.3.2/README.md
+++ b/analysed-packages/libtirpc/version-1.3.2/README.md
@@ -2,6 +2,10 @@
 
 https://sourceforge.net/projects/libtirpc/files/libtirpc/1.3.2/libtirpc-1.3.2.tar.bz2/download
 
+## Package URL (purl)
+
+pkg:none/sourceforge.net/projects/libtirpc@1.3.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/libunistring/version-1.0/README.md
+++ b/analysed-packages/libunistring/version-1.0/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:genercic/libunistring@1.0?download_url=https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
+pkg:generic/libunistring@1.0?download_url=https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/libunistring/version-1.0/README.md
+++ b/analysed-packages/libunistring/version-1.0/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/libunistring@1.0
+pkg:genercic/libunistring@1.0?download_url=https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/libunistring/version-1.0/README.md
+++ b/analysed-packages/libunistring/version-1.0/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/libunistring@1.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/lighthttpd/version-1.4.67/README.md
+++ b/analysed-packages/lighthttpd/version-1.4.67/README.md
@@ -4,7 +4,7 @@ https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.67.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/download.lighttpd.net/lighttpd/lighthttpd@1.4.67
+pkg:generic/lighthttpd@1.4.67?download_url=https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.67.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/lighthttpd/version-1.4.67/README.md
+++ b/analysed-packages/lighthttpd/version-1.4.67/README.md
@@ -2,6 +2,10 @@
 
 https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.67.tar.gz
 
+## Package URL (purl)
+
+pkg:none/download.lighttpd.net/lighttpd/lighthttpd@1.4.67
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/lodash/version-4.17.21/README.md
+++ b/analysed-packages/lodash/version-4.17.21/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/lodash/lodash/tree/4.17.21
 
+## Package URL (purl)
+
+pkg:none/github.com/lodash/lodash@4.17.21
 
 ## Reviewers
 

--- a/analysed-packages/lodash/version-4.17.21/README.md
+++ b/analysed-packages/lodash/version-4.17.21/README.md
@@ -4,7 +4,7 @@ https://github.com/lodash/lodash/tree/4.17.21
 
 ## Package URL (purl)
 
-pkg:none/github.com/lodash/lodash@4.17.21
+pkg:github/lodash/lodash@4.17.21
 
 ## Reviewers
 

--- a/analysed-packages/lvgl/version-8.3.3/README.md
+++ b/analysed-packages/lvgl/version-8.3.3/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/lvgl/lvgl/archive/refs/tags/v8.3.3.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/lvgl/lvgl@8.3.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/lvgl/version-8.3.3/README.md
+++ b/analysed-packages/lvgl/version-8.3.3/README.md
@@ -4,7 +4,7 @@ https://github.com/lvgl/lvgl/archive/refs/tags/v8.3.3.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/lvgl/lvgl@8.3.3
+pkg:github/lvgl/lvgl@8.3.3
 
 ## Reviewers
 

--- a/analysed-packages/lz4/version-1.9.4/README.md
+++ b/analysed-packages/lz4/version-1.9.4/README.md
@@ -4,7 +4,7 @@ https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/lz4/lz4@1.9.4
+pkg:github/lz4/lz4@1.9.4
 
 ## Reviewers
 

--- a/analysed-packages/lz4/version-1.9.4/README.md
+++ b/analysed-packages/lz4/version-1.9.4/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/lz4/lz4@1.9.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/mawk/version-1.3.4/README.md
+++ b/analysed-packages/mawk/version-1.3.4/README.md
@@ -4,7 +4,7 @@ https://invisible-island.net/archives/mawk/mawk-1.3.4-20200120.tgz
 
 ## Package URL (purl)
 
-pkg:none/invisible-island.net/archives/mawk@1.3.4
+pkg:generic/mawk@1.3.4-20200120?download_url=https://invisible-island.net/archives/mawk/mawk-1.3.4-20200120.tgz
 
 ## Reviewers
 

--- a/analysed-packages/mawk/version-1.3.4/README.md
+++ b/analysed-packages/mawk/version-1.3.4/README.md
@@ -2,6 +2,10 @@
 
 https://invisible-island.net/archives/mawk/mawk-1.3.4-20200120.tgz
 
+## Package URL (purl)
+
+pkg:none/invisible-island.net/archives/mawk@1.3.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/mbedtls/version-3.0.0/README.md
+++ b/analysed-packages/mbedtls/version-3.0.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.0.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/Mbed-TLS/mbedtls@3.0.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/mbedtls/version-3.0.0/README.md
+++ b/analysed-packages/mbedtls/version-3.0.0/README.md
@@ -4,7 +4,7 @@ https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.0.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/Mbed-TLS/mbedtls@3.0.0
+pkg:github/Mbed-TLS/mbedtls@3.0.0
 
 ## Reviewers
 

--- a/analysed-packages/mbedtls/version-3.2.1/README.md
+++ b/analysed-packages/mbedtls/version-3.2.1/README.md
@@ -4,7 +4,7 @@ https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.2.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/Mbed-TLS/mbedtls@3.2.1
+pkg:github/Mbed-TLS/mbedtls@3.2.1
 
 ## Reviewers
 

--- a/analysed-packages/mbedtls/version-3.2.1/README.md
+++ b/analysed-packages/mbedtls/version-3.2.1/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.2.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/Mbed-TLS/mbedtls@3.2.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/musl/version-1.2.2/README.md
+++ b/analysed-packages/musl/version-1.2.2/README.md
@@ -2,6 +2,9 @@
 
 https://git.musl-libc.org/cgit/musl/tag/?h=v1.2.2
 
+## Package URL (purl)
+
+pkg:none/git.musl-libc.org/cgit/musl@1.2.2
 
 ## Reviewers
 

--- a/analysed-packages/musl/version-1.2.2/README.md
+++ b/analysed-packages/musl/version-1.2.2/README.md
@@ -4,7 +4,7 @@ https://git.musl-libc.org/cgit/musl/tag/?h=v1.2.2
 
 ## Package URL (purl)
 
-pkg:none/git.musl-libc.org/cgit/musl@1.2.2
+pkg:generic/musl@1.2.2?download_url=https://git.musl-libc.org/cgit/musl/tag/?h=v1.2.2
 
 ## Reviewers
 

--- a/analysed-packages/musl/version-1.2.3/README.md
+++ b/analysed-packages/musl/version-1.2.3/README.md
@@ -2,6 +2,10 @@
 
 https://musl.libc.org/releases/musl-1.2.3.tar.gz
 
+## Package URL (purl)
+
+pkg:none/musl.libc.org/releases/musl@1.2.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/musl/version-1.2.3/README.md
+++ b/analysed-packages/musl/version-1.2.3/README.md
@@ -4,7 +4,7 @@ https://musl.libc.org/releases/musl-1.2.3.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/musl.libc.org/releases/musl@1.2.3
+pkg:generic/musl@1.2.3?download_url=https://musl.libc.org/releases/musl-1.2.3.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/nano/version-7.1/README.md
+++ b/analysed-packages/nano/version-7.1/README.md
@@ -2,6 +2,10 @@
 
 https://www.nano-editor.org/dist/v7/nano-7.1.tar.gz
 
+## Package URL (purl)
+
+pkg:none/www.nano-editor.org/dist/nano@7.1
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/nano/version-7.1/README.md
+++ b/analysed-packages/nano/version-7.1/README.md
@@ -4,7 +4,7 @@ https://www.nano-editor.org/dist/v7/nano-7.1.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/www.nano-editor.org/dist/nano@7.1
+pkg:generic/nano@7.1?download_url=https://www.nano-editor.org/dist/v7/nano-7.1.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/navigation2/version-1.1.3/README.md
+++ b/analysed-packages/navigation2/version-1.1.3/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/ros-planning/navigation2/archive/refs/tags/1.1.3.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/ros-planning/navigation2@1.1.3
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/navigation2/version-1.1.3/README.md
+++ b/analysed-packages/navigation2/version-1.1.3/README.md
@@ -4,7 +4,7 @@ https://github.com/ros-planning/navigation2/archive/refs/tags/1.1.3.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/ros-planning/navigation2@1.1.3
+pkg:github/ros-planning/navigation2@1.1.3
 
 ## Reviewers
 

--- a/analysed-packages/nettle/version-3.8/README.md
+++ b/analysed-packages/nettle/version-3.8/README.md
@@ -4,7 +4,7 @@ https://ftp.gnu.org/gnu/nettle/nettle-3.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/ftp.gnu.org/gnu/nettle@3.8
+pkg:generic/nettle@3.8?download_url=https://ftp.gnu.org/gnu/nettle/nettle-3.8.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/nettle/version-3.8/README.md
+++ b/analysed-packages/nettle/version-3.8/README.md
@@ -2,6 +2,10 @@
 
 https://ftp.gnu.org/gnu/nettle/nettle-3.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/ftp.gnu.org/gnu/nettle@3.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/nghttp2/version-1.50.0/README.md
+++ b/analysed-packages/nghttp2/version-1.50.0/README.md
@@ -4,7 +4,7 @@ https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.50.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/nghttp2/nghttp2@1.50.0
+pkg:github/nghttp2/nghttp2@1.50.0
 
 ## Reviewers
 

--- a/analysed-packages/nghttp2/version-1.50.0/README.md
+++ b/analysed-packages/nghttp2/version-1.50.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.50.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/nghttp2/nghttp2@1.50.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/nghttp2/version-1.51.0/README.md
+++ b/analysed-packages/nghttp2/version-1.51.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.51.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/nghttp2/nghttp2@1.51.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/nghttp2/version-1.51.0/README.md
+++ b/analysed-packages/nghttp2/version-1.51.0/README.md
@@ -4,7 +4,7 @@ https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.51.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/nghttp2/nghttp2@1.51.0
+pkg:github/nghttp2/nghttp2@1.51.0
 
 ## Reviewers
 

--- a/analysed-packages/nginx/version-1.20.2/README.md
+++ b/analysed-packages/nginx/version-1.20.2/README.md
@@ -4,7 +4,7 @@ http://nginx.org/download/nginx-1.20.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/nginx.org/download/nginx@1.20.2
+pkg:generic/nginx@1.20.2?download_url=http://nginx.org/download/nginx-1.20.2.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/nginx/version-1.20.2/README.md
+++ b/analysed-packages/nginx/version-1.20.2/README.md
@@ -2,6 +2,10 @@
 
 http://nginx.org/download/nginx-1.20.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/nginx.org/download/nginx@1.20.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/ngtcp2/version-0.11.0/README.md
+++ b/analysed-packages/ngtcp2/version-0.11.0/README.md
@@ -4,7 +4,7 @@ https://github.com/ngtcp2/ngtcp2/archive/refs/tags/v0.11.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/ngtcp2/ngtcp2@0.11.0
+pkg:github/ngtcp2/ngtcp2@0.11.0
 
 ## Reviewers
 

--- a/analysed-packages/ngtcp2/version-0.11.0/README.md
+++ b/analysed-packages/ngtcp2/version-0.11.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/ngtcp2/ngtcp2/archive/refs/tags/v0.11.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/ngtcp2/ngtcp2@0.11.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/p11-kit/version-0.24.0/README.md
+++ b/analysed-packages/p11-kit/version-0.24.0/README.md
@@ -4,7 +4,7 @@ https://github.com/p11-glue/p11-kit/archive/refs/tags/0.24.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/p11-glue/p11-kit@0.24.0
+pkg:github/p11-glue/p11-kit@0.24.0
 
 ## Reviewers
 

--- a/analysed-packages/p11-kit/version-0.24.0/README.md
+++ b/analysed-packages/p11-kit/version-0.24.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/p11-glue/p11-kit/archive/refs/tags/0.24.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/p11-glue/p11-kit@0.24.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/paho.mqtt.c/version-1.3.11/README.md
+++ b/analysed-packages/paho.mqtt.c/version-1.3.11/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.11.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/eclipse/paho.mqtt.c@1.3.11
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/paho.mqtt.c/version-1.3.11/README.md
+++ b/analysed-packages/paho.mqtt.c/version-1.3.11/README.md
@@ -4,7 +4,7 @@ https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.11.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/eclipse/paho.mqtt.c@1.3.11
+pkg:github/eclipse/paho.mqtt.c@1.3.11
 
 ## Reviewers
 

--- a/analysed-packages/pam/version-1.5.2/README.md
+++ b/analysed-packages/pam/version-1.5.2/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/linux-pam/linux-pam/archive/refs/tags/v1.5.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/linux-pam/pam@1.5.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/pam/version-1.5.2/README.md
+++ b/analysed-packages/pam/version-1.5.2/README.md
@@ -4,7 +4,7 @@ https://github.com/linux-pam/linux-pam/archive/refs/tags/v1.5.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/linux-pam/pam@1.5.2
+pkg:github/linux-pam/pam@1.5.2
 
 ## Reviewers
 

--- a/analysed-packages/protobuf/version-21.11/README.md
+++ b/analysed-packages/protobuf/version-21.11/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.11.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/protocolbuffers/protobuf@21.11
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/protobuf/version-21.11/README.md
+++ b/analysed-packages/protobuf/version-21.11/README.md
@@ -4,7 +4,7 @@ https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.11.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/protocolbuffers/protobuf@21.11
+pkg:github/protocolbuffers/protobuf@21.11
 
 ## Reviewers
 

--- a/analysed-packages/rancher/version-2.7.0/README.md
+++ b/analysed-packages/rancher/version-2.7.0/README.md
@@ -4,7 +4,7 @@ https://github.com/rancher/rancher/archive/refs/tags/v2.7.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/rancher/rancher@2.7.0
+pkg:github/rancher/rancher@2.7.0
 
 ## Reviewers
 

--- a/analysed-packages/rancher/version-2.7.0/README.md
+++ b/analysed-packages/rancher/version-2.7.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/rancher/rancher/archive/refs/tags/v2.7.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/rancher/rancher@2.7.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/rauc/version-1.8/README.md
+++ b/analysed-packages/rauc/version-1.8/README.md
@@ -4,7 +4,7 @@ https://github.com/rauc/rauc/archive/refs/tags/v1.8.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/rauc/rauc@1.8
+pkg:github/rauc/rauc@1.8
 
 ## Reviewers
 

--- a/analysed-packages/rauc/version-1.8/README.md
+++ b/analysed-packages/rauc/version-1.8/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/rauc/rauc/archive/refs/tags/v1.8.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/rauc/rauc@1.8
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/robin-hood/version-3.11.5/README.md
+++ b/analysed-packages/robin-hood/version-3.11.5/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/martinus/robin-hood-hashing/archive/refs/tags/3.11.5.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/martinus/robin-hood@3.11.5
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/robin-hood/version-3.11.5/README.md
+++ b/analysed-packages/robin-hood/version-3.11.5/README.md
@@ -4,7 +4,7 @@ https://github.com/martinus/robin-hood-hashing/archive/refs/tags/3.11.5.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/martinus/robin-hood@3.11.5
+pkg:github/martinus/robin-hood@3.11.5
 
 ## Reviewers
 

--- a/analysed-packages/ruckig/version-0.8.4/README.md
+++ b/analysed-packages/ruckig/version-0.8.4/README.md
@@ -4,7 +4,7 @@ https://github.com/pantor/ruckig/archive/refs/tags/v0.8.4.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/pantor/ruckig@0.8.4
+pkg:github/pantor/ruckig@0.8.4
 
 ## Reviewers
 

--- a/analysed-packages/ruckig/version-0.8.4/README.md
+++ b/analysed-packages/ruckig/version-0.8.4/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/pantor/ruckig/archive/refs/tags/v0.8.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/pantor/ruckig@0.8.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/seL4/version-12.1.0/README.md
+++ b/analysed-packages/seL4/version-12.1.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/seL4/seL4/archive/refs/tags/12.1.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/seL4/seL4@12.1.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/seL4/version-12.1.0/README.md
+++ b/analysed-packages/seL4/version-12.1.0/README.md
@@ -4,7 +4,7 @@ https://github.com/seL4/seL4/archive/refs/tags/12.1.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/seL4/seL4@12.1.0
+pkg:github/seL4/seL4@12.1.0
 
 ## Reviewers
 

--- a/analysed-packages/sqlite/version-3.39.4/README.md
+++ b/analysed-packages/sqlite/version-3.39.4/README.md
@@ -4,7 +4,7 @@ https://github.com/sqlite/sqlite/archive/refs/tags/version-3.39.4.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/sqlite/sqlite@3.39.4
+pkg:github/sqlite/sqlite@3.39.4
 
 ## Reviewers
 

--- a/analysed-packages/sqlite/version-3.39.4/README.md
+++ b/analysed-packages/sqlite/version-3.39.4/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/sqlite/sqlite/archive/refs/tags/version-3.39.4.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/sqlite/sqlite@3.39.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/swupdate/version-2022.05/README.md
+++ b/analysed-packages/swupdate/version-2022.05/README.md
@@ -4,7 +4,7 @@ https://github.com/sbabic/swupdate/archive/refs/tags/2022.05.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/sbabic/swupdate@2022.05
+pkg:github/sbabic/swupdate@2022.05
 
 ## Reviewers
 

--- a/analysed-packages/swupdate/version-2022.05/README.md
+++ b/analysed-packages/swupdate/version-2022.05/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/sbabic/swupdate/archive/refs/tags/2022.05.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/sbabic/swupdate@2022.05
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/systemd/version-v251/README.md
+++ b/analysed-packages/systemd/version-v251/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/systemd/systemd/archive/refs/tags/v251.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/systemd/systemd@v251
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/systemd/version-v251/README.md
+++ b/analysed-packages/systemd/version-v251/README.md
@@ -4,7 +4,7 @@ https://github.com/systemd/systemd/archive/refs/tags/v251.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/systemd/systemd@v251
+pkg:github/systemd/systemd@251
 
 ## Reviewers
 

--- a/analysed-packages/sysvinit-utils/3.04/README.md
+++ b/analysed-packages/sysvinit-utils/3.04/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/slicer69/sysvinit/archive/refs/tags/3.04.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/slicer69/sysvinit-utils@3.04
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/sysvinit-utils/3.04/README.md
+++ b/analysed-packages/sysvinit-utils/3.04/README.md
@@ -4,7 +4,7 @@ https://github.com/slicer69/sysvinit/archive/refs/tags/3.04.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/slicer69/sysvinit-utils@3.04
+pkg:github/slicer69/sysvinit-utils@3.04
 
 ## Reviewers
 

--- a/analysed-packages/toybox/version-0.8.7/README.md
+++ b/analysed-packages/toybox/version-0.8.7/README.md
@@ -4,7 +4,7 @@ http://landley.net/toybox/downloads/toybox-0.8.7.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/landley.net/toybox/toybox@0.8.7
+pkg:generic/toybox@0.8.7?download_url=http://landley.net/toybox/downloads/toybox-0.8.7.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/toybox/version-0.8.7/README.md
+++ b/analysed-packages/toybox/version-0.8.7/README.md
@@ -2,6 +2,10 @@
 
 http://landley.net/toybox/downloads/toybox-0.8.7.tar.gz
 
+## Package URL (purl)
+
+pkg:none/landley.net/toybox/toybox@0.8.7
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/u-boot/version-2022.04/README.md
+++ b/analysed-packages/u-boot/version-2022.04/README.md
@@ -4,7 +4,7 @@ https://source.denx.de/u-boot/u-boot/-/archive/v2022.04/u-boot-v2022.04.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/source.denx.de/u-boot/u-boot@2022.04
+pkg:generic/u-boot@2022.04?download_url=https://source.denx.de/u-boot/u-boot/-/archive/v2022.04/u-boot-v2022.04.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/u-boot/version-2022.04/README.md
+++ b/analysed-packages/u-boot/version-2022.04/README.md
@@ -2,6 +2,10 @@
 
 https://source.denx.de/u-boot/u-boot/-/archive/v2022.04/u-boot-v2022.04.tar.gz
 
+## Package URL (purl)
+
+pkg:none/source.denx.de/u-boot/u-boot@2022.04
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/usbutils/version-v015/README.md
+++ b/analysed-packages/usbutils/version-v015/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/gregkh/usbutils/archive/refs/tags/v015.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/gregkh/usbutils@v015
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/usbutils/version-v015/README.md
+++ b/analysed-packages/usbutils/version-v015/README.md
@@ -4,7 +4,7 @@ https://github.com/gregkh/usbutils/archive/refs/tags/v015.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/gregkh/usbutils@v015
+pkg:github/gregkh/usbutils@015
 
 ## Reviewers
 

--- a/analysed-packages/xxHash/version-0.8.0/README.md
+++ b/analysed-packages/xxHash/version-0.8.0/README.md
@@ -4,7 +4,7 @@ https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/Cyan4973/xxHash@0.8.0
+pkg:github/Cyan4973/xxHash@0.8.0
 
 ## Reviewers
 

--- a/analysed-packages/xxHash/version-0.8.0/README.md
+++ b/analysed-packages/xxHash/version-0.8.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/Cyan4973/xxHash@0.8.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/xz-utils/version-5.2.5/README.md
+++ b/analysed-packages/xz-utils/version-5.2.5/README.md
@@ -2,6 +2,10 @@
 
 https://sourceforge.net/projects/lzmautils/files/xz-5.2.5.tar.gz/download
 
+## Package URL (purl)
+
+pkg:none/sourceforge.net/projects/xz-utils@5.2.5
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/xz-utils/version-5.2.5/README.md
+++ b/analysed-packages/xz-utils/version-5.2.5/README.md
@@ -4,7 +4,7 @@ https://sourceforge.net/projects/lzmautils/files/xz-5.2.5.tar.gz/download
 
 ## Package URL (purl)
 
-pkg:none/sourceforge.net/projects/xz-utils@5.2.5
+pkg:generic/xz-utils@5.2.5?download_url=https://sourceforge.net/projects/lzmautils/files/xz-5.2.5.tar.gz/download
 
 ## Reviewers
 

--- a/analysed-packages/yaml-cpp/version-0.7.0/README.md
+++ b/analysed-packages/yaml-cpp/version-0.7.0/README.md
@@ -4,7 +4,7 @@ https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/jbeder/yaml-cpp@0.7.0
+pkg:github/jbeder/yaml-cpp@0.7.0
 
 ## Reviewers
 

--- a/analysed-packages/yaml-cpp/version-0.7.0/README.md
+++ b/analysed-packages/yaml-cpp/version-0.7.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/jbeder/yaml-cpp@0.7.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/zephyr/version-2.7.2/README.md
+++ b/analysed-packages/zephyr/version-2.7.2/README.md
@@ -4,7 +4,7 @@ https://github.com/zephyrproject-rtos/zephyr/archive/refs/tags/v2.7.2.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/zephyrproject-rtos/zephyr@2.7.2
+pkg:github/zephyrproject-rtos/zephyr@2.7.2
 
 ## Reviewers
 

--- a/analysed-packages/zephyr/version-2.7.2/README.md
+++ b/analysed-packages/zephyr/version-2.7.2/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/zephyrproject-rtos/zephyr/archive/refs/tags/v2.7.2.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/zephyrproject-rtos/zephyr@2.7.2
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/zephyr/version-3.2.0/README.md
+++ b/analysed-packages/zephyr/version-3.2.0/README.md
@@ -4,7 +4,7 @@ https://github.com/zephyrproject-rtos/zephyr/archive/refs/tags/zephyr-v3.2.0.tar
 
 ## Package URL (purl)
 
-pkg:none/github.com/zephyrproject-rtos/zephyr@3.2.0
+pkg:github/zephyrproject-rtos/zephyr@3.2.0
 
 ## Reviewers
 

--- a/analysed-packages/zephyr/version-3.2.0/README.md
+++ b/analysed-packages/zephyr/version-3.2.0/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/zephyrproject-rtos/zephyr/archive/refs/tags/zephyr-v3.2.0.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/zephyrproject-rtos/zephyr@3.2.0
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/zeroMQ/libzmq/version-4.3.4/README.md
+++ b/analysed-packages/zeroMQ/libzmq/version-4.3.4/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.4.tar.gz
 
+## Package URL (purl)
+
+pkg:github/zeromq/libzmq@4.3.4
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/zlib/version-1.2.11/README.md
+++ b/analysed-packages/zlib/version-1.2.11/README.md
@@ -4,7 +4,7 @@ https://zlib.net/fossils/zlib-1.2.11.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/zlib.net/fossils/zlib@1.2.11
+pkg:generic/zlib@1.2.11?download_url=https://zlib.net/fossils/zlib-1.2.11.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/zlib/version-1.2.11/README.md
+++ b/analysed-packages/zlib/version-1.2.11/README.md
@@ -2,8 +2,12 @@
 
 https://zlib.net/fossils/zlib-1.2.11.tar.gz
 
+## Package URL (purl)
+
+pkg:none/zlib.net/fossils/zlib@1.2.11
 
 ## Reviewers
+
 The information was reviewed by:
 
 * add reviewer here

--- a/analysed-packages/zlib/version-1.2.12/README.md
+++ b/analysed-packages/zlib/version-1.2.12/README.md
@@ -4,7 +4,7 @@ https://zlib.net/fossils/zlib-1.2.12.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/zlib.net/fossils/zlib@1.2.12
+pkg:generic/zlib@1.2.12?download_url=https://zlib.net/fossils/zlib-1.2.12.tar.gz
 
 ## Reviewers
 

--- a/analysed-packages/zlib/version-1.2.12/README.md
+++ b/analysed-packages/zlib/version-1.2.12/README.md
@@ -2,6 +2,10 @@
 
 https://zlib.net/fossils/zlib-1.2.12.tar.gz
 
+## Package URL (purl)
+
+pkg:none/zlib.net/fossils/zlib@1.2.12
+
 ## Reviewers
 
 The information was reviewed by:

--- a/analysed-packages/zstd/version-1.4.10/README.md
+++ b/analysed-packages/zstd/version-1.4.10/README.md
@@ -4,7 +4,7 @@ https://github.com/facebook/zstd/archive/refs/tags/v1.4.10.tar.gz
 
 ## Package URL (purl)
 
-pkg:none/github.com/facebook/zstd@1.4.10
+pkg:github/facebook/zstd@1.4.10
 
 ## Reviewers
 

--- a/analysed-packages/zstd/version-1.4.10/README.md
+++ b/analysed-packages/zstd/version-1.4.10/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/facebook/zstd/archive/refs/tags/v1.4.10.tar.gz
 
+## Package URL (purl)
+
+pkg:none/github.com/facebook/zstd@1.4.10
+
 ## Reviewers
 
 The information was reviewed by:


### PR DESCRIPTION
Followed Philippe's suggestions and adapted all README.md files accordingly. Found a solution for nested packages such as Alpine: The download location of the project's archive is maintained, and the original download location is given in the purl. This made it possible to maintain a coherent syntax of the first lines of the README.md files.