### PR TITLE
Update zlib-1.2.12-OSS-disclosure.txt

### DIFF
--- a/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-OSS-disclosure.txt
+++ b/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-OSS-disclosure.txt
@@ -520,7 +520,6 @@ Copyright (C) 1998 by Andreas R. Kleinert
 Copyright (C) 1998 - 2010 Gilles Vollant, Even Rouault, Mathias Svensson
 Copyright (C) 1995-2022 Mark Adler
 Copyright (C) 1995-2022 Jean-loup Gailly, Mark Adler
-Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler 
 Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
 Copyright (C) 1995-2022 Jean-loup Gailly & Mark Adler
 Copyright (C) 1995-2021 Jean-loup Gailly detect_data_type() function provided


### PR DESCRIPTION
One entry with space at the end but the same content could be removed "Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler"