### PR TITLE
Update zlib-1.2.12-SPDX2TV.spdx

### DIFF
--- a/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx
+++ b/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx
@@ -3347,7 +3347,7 @@ FileChecksum: SHA256: 143394d1e3876c61c29078c0e47310e726e1f5bd42739fe92df9ece657
 FileChecksum: MD5: 4d8dfda2096227d68f03499480c3740c
 LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NOASSERTION
-FileCopyrightText: <text> Copyright (C) 1995-2017 Jean-Loup Gailly, Mark Adler </text>
+FileCopyrightText: NOASSERTION
  
 
 ##File


### PR DESCRIPTION
In the file there is the code
"echo '#pragma comment(copyright, "Copyright (C) 1995-2017 Jean-Loup Gailly, Mark Adler. OS/400 version by P. Monnerat.")' >> os400.c" For me this line does not indicate the copyright of make.sh.