### PR TITLE
Update zlib-1.2.12-SPDX2TV.spdx

### DIFF
--- a/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx
+++ b/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx
@@ -1986,8 +1986,8 @@ FileChecksum: SHA1: 35f85759bc23add6a8507c76d05f73131823a9b3
 FileChecksum: SHA256: 80fb647be8450bd7a07d8495244e1f061dfbdbdb53172ca24e7ffff8ace9c72f
 FileChecksum: MD5: f4912cf5a1ade2e862e193983c02b3ee
 LicenseConcluded: NOASSERTION
-LicenseInfoInFile: LicenseRef-Public-domain
-LicenseInfoInFile: LicenseRef-LicenseRef-scancode-public-domain
+LicenseInfoInFile: NOASSERTION
+LicenseInfoInFile: NOASSERTION
 FileCopyrightText: NOASSERTION
  
 


### PR DESCRIPTION
In the "zlib_how.html" there is a description how to use the example zpipe.c.
In the header of zpipe.c there is a comment with "provided to the public domain". But does it mean the description is also under public domain? For me not. If the pull request would be accepted then the "Copyright (c) 2004, 2005 by Mark Adler" must be added.