### PR TITLE
add workflow to validate that all files are valid

### DIFF
--- a/.github/workflows/scripts/spdx-tools-java-wrapper.sh
+++ b/.github/workflows/scripts/spdx-tools-java-wrapper.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+set -euo pipefail
+
+version="1.1.4"
+zip="tools-java-${version}.zip"
+url="https://github.com/spdx/tools-java/releases/download/v${version}/${zip}"
+jar="$HOME/spdx-tools-java/tools-java-${version}-jar-with-dependencies.jar"
+
+bootstrap() {
+    if [[ ! -f "$jar" ]]; then
+        wget -q "$url"
+        unzip "$zip" -d "$(dirname "$jar")" "$(basename "$jar")"
+        rm "$zip"
+
+        java -jar "$jar"
+    fi
+}
+
+verify() {
+    local tmpfile="$(mktemp)"
+    find analysed-packages/ -iname '*.spdx' -print0 |
+        while IFS= read -r -d '' spdx; do
+            java -jar "$jar" Verify "$spdx" || {
+                echo "$spdx" >> "$tmpfile"
+            }
+        done
+
+    echo
+    if [[ -s "$tmpfile" ]]; then
+        echo "################################################################################"
+        echo "The following .spdx files are not valid, see logs above:"
+        echo
+        cat "$tmpfile"
+        echo "################################################################################"
+        exit 1
+    else
+        echo "################################################################################"
+        echo "all .spdx files are valid"
+        echo "################################################################################"
+    fi
+}
+
+"$@"

--- a/.github/workflows/spdx-tools-java.yml
+++ b/.github/workflows/spdx-tools-java.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: spdx/tools-java workflow
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  syntax-check-of-tag-value:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: "bootstrap spdx/tools-java"
+        run: .github/workflows/scripts/spdx-tools-java-wrapper.sh bootstrap
+      - name: "verify all tag-value documents"
+        run: .github/workflows/scripts/spdx-tools-java-wrapper.sh verify


### PR DESCRIPTION
This adds a (long runing) CI job, which check all `.spdx` files with `spdx/tools-java` and lists all documents which are not valid. It fails, when at least one document is invalid.

### Licensing:
Which license to use for the code part of this repository? Also CC0 1.0, or maybe some permissive license?

### Current state
Currently invalid are, mostly due to reasons like `License not found for LicenseRef-GPL-1.0`, are:

```
analysed-packages/nettle/version-3.8/nettle-3.8-SPDX2TV.spdx
analysed-packages/kbd/version-2.5.1/kbd-2.5.1-SPDX2TV.spdx
analysed-packages/brotli/version-1.0.9/brotli-1.0.9-SPDX2TV.spdx
analysed-packages/attr/version-2.4.48/attr-2.4.48-SPDX2TV.spdx
analysed-packages/attr/version-2.5.1/attr-2.5.1-SPDX2TV.spdx
analysed-packages/allwpilib/version-2022.4.1/allwpilib-2022.4.1-SPDX2TV.spdx
analysed-packages/shim/version-15.7/shim-15.7-SPDX2TV.spdx
analysed-packages/u-boot/version-2022.04/u-boot-v2022.04-SPDX2TV.spdx
analysed-packages/libtirpc/version-1.3.2/libtirpc-1.3.2-SPDX2TV.spdx
analysed-packages/gzip/version-1.12/gzip-1.12-SPDX2TV.spdx
analysed-packages/dart-lang/characters/version-1.2.0/characters-1.2.0-SPDX2TV.spdx
analysed-packages/react/version-18.2.0/react-18.2.0-SPDX2TV.spdx
analysed-packages/bootstrap/version-5.1.3/bootstrap-5.1.3-SPDX2TV.spdx
analysed-packages/bootstrap/version-5.2.3/bootstrap-5.2.3-SPDX2TV.spdx
analysed-packages/ngtcp2/version-0.11.0/ngtcp2-0.11.0-SPDX2TV.spdx
analysed-packages/libpng/version-1.6.38/libpng-1.6.38-SPDX2TV.spdx
analysed-packages/swupdate/version-2022.05/swupdate-2022.05-SPDX2TV.spdx
analysed-packages/libffi/version-3.4.0/libffi-3.4.0-SPDX2TV.spdx
analysed-packages/jpeg/version-v9e/jpegsrc.v9e-SPDX2TV.spdx
analysed-packages/grep/version-3.6/grep-3.6-SPDX2TV.spdx
analysed-packages/libsepol/version-3.4/libsepol-3.4-SPDX2TV.spdx
analysed-packages/protobuf/version-21.11/protobuf-21.11-SPDX2TV.spdx
analysed-packages/usbutils/version-v015/usbutils-015-SPDX2TV.spdx
analysed-packages/lighthttpd/version-1.4.67/lighttpd-1.4.67-SPDX2TV.spdx
analysed-packages/libselinux/version-3.4/libselinux-3.4-SPDX2TV.spdx
analysed-packages/checkpolicy/version-3.4/checkpolicy-3.4-SPDX2TV.spdx
analysed-packages/klibc/version-2.0.11/klibc-2.0.11-SPDX2TV.spdx
analysed-packages/nginx/version-1.20.2/nginx-1.20.2-SPDX2TV.spdx
analysed-packages/zstd/version-1.4.10/zstd-1.4.10-SPDX2TV.spdx
analysed-packages/flutter/version-3.3.8/flutter-3.3.8-SPDX2TV.spdx
analysed-packages/dbus/version-1.12.24/dbus-1.12.24-SPDX2TV.spdx
analysed-packages/dbus/version-1.15.2/dbus-1.15.2-SPDX2TV.spdx
analysed-packages/diffutils/version-3.5/diffutils-3.5-SPDX2TV.spdx
analysed-packages/ffmpeg/version-n5.1.2/FFmpeg-n5.1.2-SPDX2TV.spdx
analysed-packages/ffmpeg/version-n5.1.1/FFmpeg-n5.1.1-SPDX2TV.spdx
analysed-packages/keyutils/version-1.6.1/keyutils-1.6.1-SPDX2TV.spdx
analysed-packages/sysvinit-utils/3.04/sysvinit-3.04-SPDX2TV.spdx
analysed-packages/hiawatha/version-11.2/hiawatha-11.2-SPDX2TV.spdx
analysed-packages/libgpg-error/version-1.46/libgpg-error-1.46-SPDX2TV.spdx
analysed-packages/rauc/version-1.8/rauc-1.8-SPDX2TV.spdx
analysed-packages/p11-kit/version-0.24.0/p11-kit-0.24.0-SPDX2TV.spdx
analysed-packages/sqlite/version-3.39.4/sqlite-3.39.4-SPDX2TV.spdx
analysed-packages/expat/version-2.5.0/libexpat-2.5.0-SPDX2TV.spdx
analysed-packages/ruckig/version-0.8.4/ruckig-0.8.4-SPDX2TV.spdx
analysed-packages/systemd/version-v251/systemd-251-SPDX2TV.spdx
analysed-packages/dash/version-0.5.11.4/dash-0.5.11.5-SPDX2TV.spdx
analysed-packages/tar/version-1.34/tar-1.34-SPDX2TV.spdx
analysed-packages/paho.mqtt.c/version-1.3.11/paho.mqtt.c-1.3.11-SPDX2TV.spdx
analysed-packages/nghttp2/version-1.51.0/nghttp2-1.51.0-SPDX2TV.spdx
analysed-packages/nghttp2/version-1.50.0/nghttp2-1.50.0-SPDX2TV.spdx
analysed-packages/robin-hood/version-3.11.5/robin-hood-3.11.5-SPDX2TV.spdx
analysed-packages/busybox/version-1.35.0/busybox-1.35.0-SPDX2TV.spdx
analysed-packages/curl/version-7.86.0/curl-7.86.0-SPDX2TV.spdx
analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/busybox-1.34.1-SPDX2TV.spdx
analysed-packages/Alpine/version-3.15/musl-version-1.2.2/musl-1.2.2-SPDX2TV.spdx
analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/ca-certificates-20211220-SPDX2TV.spdx
analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/alpine-baselayout-3.2.0-SPDX2TV.spdx
analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/pax-utils-1.3.3-SPDX2TV.spdx
analysed-packages/acl/version-2.2.53/acl-2.2.53-SPDX2TV.spdx
analysed-packages/acl/version-2.3.1/acl-2.3.1-SPDX2TV.spdx
analysed-packages/gnutls/version-3.7.8/gnutls-3.7.8-SPDX2TV.spdx
analysed-packages/seL4/version-12.1.0/seL4-12.1.0-SPDX2TV.spdx
analysed-packages/grub2/version-2.06/grub-2.06-SPDX2TV.spdx
analysed-packages/coreutils/version-9.1/coreutils-9.1-SPDX2TV.spdx
analysed-packages/navigation2/version-1.1.3/navigation2-1.1.3-SPDX2TV.spdx
analysed-packages/mbedtls/version-3.2.1/mbedtls-3.2.1-SPDX2TV.spdx
analysed-packages/initramfs-tools/version-0.142/initramfs-tools-v0.142-SPDX2TV.spdx
analysed-packages/ethtool/version-6.1/ethtool-6.1-SPDX2TV.spdx
analysed-packages/yaml-cpp/version-0.7.0/yaml-0.7.0-SPDX2TV.spdx
analysed-packages/rancher/version-2.7.0/rancher-2.7.0-SPDX2TV.spdx
analysed-packages/libsemanage/version-3.4/libsemanage-3.4-SPDX2TV.spdx
analysed-packages/zeroMQ/libzmq/version-4.3.4/libzmq-4.3.4-SPDX2TV.spdx
analysed-packages/nano/version-7.1/nano-7.1-SPDX2TV.spdx
analysed-packages/OpenSSL/version-3.0.7/openssl-3.0.7-SPDX2TV.spdx
analysed-packages/cpio/version-2.13/cpio-2.13-SPDX2TV.spdx
analysed-packages/behaviorTree.CPP/version-3.8.0/BehaviorTree.CPP-3.8.0-SPDX2TV.spdx
analysed-packages/coreboot/version-4.16/coreboot-4.16-SPDX2TV.spdx
analysed-packages/glib/version-2.75.2/glib-2.75.2-SPDX2TV.spdx
```