### PR TITLE
Do some improvements on the spdx-tools wrapper script

### DIFF
--- a/.github/workflows/scripts/spdx-tools-java-wrapper.sh
+++ b/.github/workflows/scripts/spdx-tools-java-wrapper.sh
@@ -8,42 +8,54 @@
 set -euo pipefail
 
 version="1.1.4"
-zip="tools-java-${version}.zip"
-url="https://github.com/spdx/tools-java/releases/download/v${version}/${zip}"
 jar="$HOME/spdx-tools-java/tools-java-${version}-jar-with-dependencies.jar"
 
-if [[ -n "$JAVA_HOME" && -x "$JAVA_HOME/bin/java" ]]; then
-    javabin="$JAVA_HOME/bin/java"
-else
-    javabin=java
-fi
+spdx_tools() {
+    local javabin
+    if [[ -n "${JAVA_HOME+x}" && -x "$JAVA_HOME/bin/java" ]]; then
+        javabin="$JAVA_HOME/bin/java"
+    else
+        javabin=java
+    fi
+
+    "$javabin" -jar "$jar" "$@"
+}
 
 bootstrap() {
     [[ -f "$jar" ]] && return
+
+    local zip="tools-java-${version}.zip"
+    local url="https://github.com/spdx/tools-java/releases/download/v${version}/${zip}"
 
     curl -LOs "$url"
     unzip "$zip" -d "$(dirname "$jar")" "$(basename "$jar")"
     rm "$zip"
 
-    "$javabin" -jar "$jar" Version
+    spdx_tools Version
 }
 
-verify() {
+verify_one() {
+    local spdx="$1"
+    >&2 echo -e "\nVerify $spdx\n"
+
     # Set default values that work to link to local files below.
-    GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-}"
     GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-.}"
     GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-.}"
     GITHUB_SHA="${GITHUB_SHA:-..}"
 
-    if [[ -z "$GITHUB_STEP_SUMMARY" ]]; then
+    spdx_tools Verify "$spdx" 1>&2 || echo "* [$spdx]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/$spdx)"
+}
+
+verify() {
+    if [[ -z "${GITHUB_STEP_SUMMARY+x}" ]]; then
         GITHUB_STEP_SUMMARY="$(mktemp)"
         echo "Writing local job summary to '$GITHUB_STEP_SUMMARY'."
     fi
 
     # TODO: Limit this to only the files modified in a PR.
     find analysed-packages/ -iname '*.spdx' -print0 | \
-        xargs -0 -P8 -I {} \
-        bash -c "'$javabin' -jar '$jar' Verify {} || echo '* [{}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/{})' >> '$GITHUB_STEP_SUMMARY'"
+        xargs -0 -P"$(nproc)" -I {} \
+        bash -c "'$0' verify_one '{}'" >> "$GITHUB_STEP_SUMMARY"
 
     if [[ -s "$GITHUB_STEP_SUMMARY" ]]; then
         local count=$(wc -l < "$GITHUB_STEP_SUMMARY")

--- a/.github/workflows/spdx-tools-java.yml
+++ b/.github/workflows/spdx-tools-java.yml
@@ -14,10 +14,25 @@ jobs:
   syntax-check-of-tag-value:
     runs-on: ubuntu-latest
     steps:
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: "bootstrap spdx/tools-java"
         run: .github/workflows/scripts/spdx-tools-java-wrapper.sh bootstrap
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.spdx
+
+      - name: "verify changed tag-value documents"
+        run: .github/workflows/scripts/spdx-tools-java-wrapper.sh verify_many ${{ steps.changed-files.outputs.all_changed_files }}
+        if: github.event_name == 'pull_request'
+
       - name: "verify all tag-value documents"
         run: .github/workflows/scripts/spdx-tools-java-wrapper.sh verify
+        if: github.event_name != 'pull_request'


### PR DESCRIPTION
* now runs, even if `JAVA_HOME` is not set
* runs on all cores, not just pinned to 8
* write a way less complex inline bash command

still open (but out of scope):
- [x] with parallel execution, the log is pretty unusable
  - for PRs this is solved. For main runs this is not so important