### PR TITLE
add missing copyrights to actions scripts

### DIFF
--- a/.github/workflows/scripts/spdx-tools-java-wrapper.sh
+++ b/.github/workflows/scripts/spdx-tools-java-wrapper.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
 # SPDX-FileCopyrightText: Sebastian Schuberth <sschuberth@gmail.com>
+# SPDX-FileCopyrightText: Helio Chissini de Castro <heliocastro@gmail.com>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/spdx-tools-java.yml
+++ b/.github/workflows/spdx-tools-java.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
+# SPDX-FileCopyrightText: Helio Chissini de Castro <heliocastro@gmail.com>
 #
 # SPDX-License-Identifier: CC0-1.0
 


### PR DESCRIPTION
sorry for https://github.com/Open-Source-Compliance/package-analysis/pull/24#issuecomment-1410051758

This PR adds the copyright entries, which were missed when copying a few lines from #27 to #24

ping @heliocastro