### PR TITLE
fix: bug in generating the markdown report for .spdx verification

### DIFF
--- a/.github/workflows/scripts/verify.sh
+++ b/.github/workflows/scripts/verify.sh
@@ -59,13 +59,16 @@ verify_all() {
 
     find analysed-packages/ -iname '*.spdx' -print0 | \
         xargs -0 -P"$(nproc)" -I {} \
-        bash -c "'$0' '{}'" >> "$GITHUB_STEP_SUMMARY"
+        bash -c "'$0' one '{}'" >> "$GITHUB_STEP_SUMMARY"
 
     check_github_step_summary
 }
 
 if [[ $# -eq 1 && "$1" == "all" ]]; then
     verify_all
+elif [[ $# -eq 2 && "$1" == "one" ]]; then
+    shift
+    verify_one "$1"
 else
     verify_many "$@"
 fi


### PR DESCRIPTION
the all loop should not repetetly call `verify_many` but instead should use `verify_one`. So that `check_github_step_summary` is only called once.

Otherwise the report looks like:
![2023-02-01_18-01-41](https://user-images.githubusercontent.com/1187050/216111048-b3b9c7e0-db8c-4a26-bd93-8f1fd68340ce.png)
