### PR TITLE
downgrade spdx-tools, due to spdx/tools-java#/105

### DIFF
--- a/.github/workflows/scripts/spdx-tools-java-wrapper.sh
+++ b/.github/workflows/scripts/spdx-tools-java-wrapper.sh
@@ -8,7 +8,9 @@
 
 set -euo pipefail
 
-version="1.1.4"
+# version 1.1.4 currently has a bug in handling of multiple LicenseInfoInFile entries
+# see: https://github.com/spdx/tools-java/issues/105
+version="1.1.3"
 jar="$HOME/spdx-tools-java/tools-java-${version}-jar-with-dependencies.jar"
 
 spdx_tools() {


### PR DESCRIPTION
There is a minor bug in the latest spdx/tools-java project (https://github.com/spdx/tools-java/issues/105) and it prevents some spdx files to be parsed correctly.