### PR TITLE
add 'do not verify if already verified' functionallity

### DIFF
--- a/.github/workflows/scripts/spdx-tools-java-wrapper.sh
+++ b/.github/workflows/scripts/spdx-tools-java-wrapper.sh
@@ -8,9 +8,7 @@
 
 set -euo pipefail
 
-# version 1.1.4 currently has a bug in handling of multiple LicenseInfoInFile entries
-# see: https://github.com/spdx/tools-java/issues/105
-version="1.1.3"
+version="1.1.7"
 jar="$HOME/spdx-tools-java/tools-java-${version}-jar-with-dependencies.jar"
 
 spdx_tools() {

--- a/.verifications/analysed-packages/Alpine/version-3.15/alpine-base-3.15.0/alpine-base-3.15.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/alpine-base-3.15.0/alpine-base-3.15.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+8799d89521dd26311cf604f7c5a24bd1f0b739fc  analysed-packages/Alpine/version-3.15/alpine-base-3.15.0/alpine-base-3.15.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/alpine-baselayout-3.2.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/alpine-baselayout-3.2.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+df24646f80663dbfc7e12194845d2f91038278bd  analysed-packages/Alpine/version-3.15/alpine-baselayout-3.2.0/alpine-baselayout-3.2.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/alpine-conf-3.13.0/alpine-conf-3.13.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/alpine-conf-3.13.0/alpine-conf-3.13.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+9e457ba41cc07941dfdceac98f0db2253db0bdc6  analysed-packages/Alpine/version-3.15/alpine-conf-3.13.0/alpine-conf-3.13.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/alpine-keys-2.4/alpine-keys-2.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/alpine-keys-2.4/alpine-keys-2.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+72722c9f377bc92bde2cc59cbe13fc990ef779e3  analysed-packages/Alpine/version-3.15/alpine-keys-2.4/alpine-keys-2.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/apk-tools-2.12.7/apk-tools-2.12.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/apk-tools-2.12.7/apk-tools-2.12.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+eb51ec5f64c1060a89ec41f8a25d79328c4e7f0f  analysed-packages/Alpine/version-3.15/apk-tools-2.12.7/apk-tools-2.12.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/busybox-initscripts-version-4.0/busybox-initscripts-4.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/busybox-initscripts-version-4.0/busybox-initscripts-4.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7537e373936da46da62df40f8dd292ec8fbdbae2  analysed-packages/Alpine/version-3.15/busybox-initscripts-version-4.0/busybox-initscripts-4.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/busybox-1.34.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/busybox-1.34.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d2a2a5bd251e03b89c035fdb4743ac131f5e6316  analysed-packages/Alpine/version-3.15/busybox-version-1.34.1/busybox-1.34.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/ca-certificates-20211220-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/ca-certificates-20211220-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+121409fc93b2551a09598a227685f2cf8c88b066  analysed-packages/Alpine/version-3.15/ca-certificates-version-20211220/ca-certificates-20211220-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/ifupdown-ng-version-0.11.3/ifupdown-ng-0.11.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/ifupdown-ng-version-0.11.3/ifupdown-ng-0.11.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+8f112c633a7e52cb15d83c4c5e19f6536dff8607  analysed-packages/Alpine/version-3.15/ifupdown-ng-version-0.11.3/ifupdown-ng-0.11.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/libc-dev-version-0.7.2/libc-dev-0.7.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/libc-dev-version-0.7.2/libc-dev-0.7.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+93465ae9f35977950f9759aeaa4439ed5a1ffcaa  analysed-packages/Alpine/version-3.15/libc-dev-version-0.7.2/libc-dev-0.7.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/libretls-version-3.3.4/libretls-3,3,4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/libretls-version-3.3.4/libretls-3,3,4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6c1113bead7964c340135832aa6a569c599b184e  analysed-packages/Alpine/version-3.15/libretls-version-3.3.4/libretls-3,3,4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/musl-version-1.2.2/musl-1.2.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/musl-version-1.2.2/musl-1.2.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+515a37acd8473bb1f04461783e8d970e0f7e4283  analysed-packages/Alpine/version-3.15/musl-version-1.2.2/musl-1.2.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/openSSL-version-1.1.1l/openssl-1.1.1l-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/openSSL-version-1.1.1l/openssl-1.1.1l-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6116cdc6c7eb51809779af90c1c0e385f5e264a0  analysed-packages/Alpine/version-3.15/openSSL-version-1.1.1l/openssl-1.1.1l-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/openrc-version-0.44.7/openrc-0.44.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/openrc-version-0.44.7/openrc-0.44.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2046e43e3002e40084e06c50b631a7a8caed40a5  analysed-packages/Alpine/version-3.15/openrc-version-0.44.7/openrc-0.44.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/pax-utils-1.3.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/pax-utils-1.3.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6488590e0a2324a66cd4c3f69c54b128a68e6736  analysed-packages/Alpine/version-3.15/pax-utils-version-1.3.3/pax-utils-1.3.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/Alpine/version-3.15/zlib-version-1.2.11/zlib1.2.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/Alpine/version-3.15/zlib-version-1.2.11/zlib1.2.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+5a5beeed350fe1ba218bf80f60ae5faa85359973  analysed-packages/Alpine/version-3.15/zlib-version-1.2.11/zlib1.2.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/FreeRTOS-Kernel/version-10.5.1/FreeRTOS-Kernel-10.5.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/FreeRTOS-Kernel/version-10.5.1/FreeRTOS-Kernel-10.5.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2118236cb39ba8b6d5b6d414a0c484d399141517  analysed-packages/FreeRTOS-Kernel/version-10.5.1/FreeRTOS-Kernel-10.5.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-1.1.1q/openssl-1.1.1q-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-1.1.1q/openssl-1.1.1q-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4fc3a35450fa597029562c0dbef3f95e17b41d96  analysed-packages/OpenSSL/version-1.1.1q/openssl-1.1.1q-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-1.1.1s/openssl-1.1.1s-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-1.1.1s/openssl-1.1.1s-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b16d64817c0bccbe985c620c1fabd999d627d0ca  analysed-packages/OpenSSL/version-1.1.1s/openssl-1.1.1s-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-1.1.1t/openssl-1.1.1t-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-1.1.1t/openssl-1.1.1t-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+512f2f36f18cc870f8c88f2a86dcb7258e78599b  analysed-packages/OpenSSL/version-1.1.1t/openssl-1.1.1t-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.0.3/openssl-3.0.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.0.3/openssl-3.0.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0932bf4404b98ea6836daf216de9188a11c31f18  analysed-packages/OpenSSL/version-3.0.3/openssl-3.0.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.0.5/openssl-3.0.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.0.5/openssl-3.0.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1eb618627e59425c4325fe6edf2a5e90f7a3c9c1  analysed-packages/OpenSSL/version-3.0.5/openssl-3.0.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.0.7/openssl-3.0.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.0.7/openssl-3.0.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+dce7f8bf7c190bc480506466e274277a4c84bb8c  analysed-packages/OpenSSL/version-3.0.7/openssl-3.0.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.0.8/openssl-3.0.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.0.8/openssl-3.0.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ded8c7631f4209e24af1278a2de4085e653e3249  analysed-packages/OpenSSL/version-3.0.8/openssl-3.0.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.1.0/openssl-3.1.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.1.0/openssl-3.1.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e2fe4ee87da633ea0cd65048a2e1f4504f1356cb  analysed-packages/OpenSSL/version-3.1.0/openssl-3.1.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/OpenSSL/version-3.1.1/openssl-3.1.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/OpenSSL/version-3.1.1/openssl-3.1.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+5955a51a9c12f9eebe663fefc1115bfa3673e480  analysed-packages/OpenSSL/version-3.1.1/openssl-3.1.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/RIOT/version-2023.01/RIOT-2023.01-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/RIOT/version-2023.01/RIOT-2023.01-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+17a8d01e7b0a8166cb2bf4f7e87465de3d04d3f6  analysed-packages/RIOT/version-2023.01/RIOT-2023.01-SPDX2TV.spdx

--- a/.verifications/analysed-packages/RIOT/version-2023.04/RIOT-2023.04-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/RIOT/version-2023.04/RIOT-2023.04-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+00e97d261bb02889dfd16c3d98514b3fc3e4d9e8  analysed-packages/RIOT/version-2023.04/RIOT-2023.04-SPDX2TV.spdx

--- a/.verifications/analysed-packages/acl/version-2.2.53/acl-2.2.53-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/acl/version-2.2.53/acl-2.2.53-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+691d995428ccc774a4c69086913464a5edad3a21  analysed-packages/acl/version-2.2.53/acl-2.2.53-SPDX2TV.spdx

--- a/.verifications/analysed-packages/acl/version-2.3.1/acl-2.3.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/acl/version-2.3.1/acl-2.3.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+654deb81b32fcebbc627e6873e0050bdbf8c2013  analysed-packages/acl/version-2.3.1/acl-2.3.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ajv/version-8.10.0/ajv-8.10.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ajv/version-8.10.0/ajv-8.10.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ff0239da7c915bc66e8a6a7d25851ada84799189  analysed-packages/ajv/version-8.10.0/ajv-8.10.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/allwpilib/version-2022.4.1/allwpilib-2022.4.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/allwpilib/version-2022.4.1/allwpilib-2022.4.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+63f20e1f0ed7269e702eb248998bd44f7dcf54a0  analysed-packages/allwpilib/version-2022.4.1/allwpilib-2022.4.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/allwpilib/version-2023.4.3/allwpilib-2023.4.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/allwpilib/version-2023.4.3/allwpilib-2023.4.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ab4eac49fb7a9aad70d8fc06b27ab2cf8598cf23  analysed-packages/allwpilib/version-2023.4.3/allwpilib-2023.4.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/alsa-lib/version-1.2.8/alsa-lib-1.2.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/alsa-lib/version-1.2.8/alsa-lib-1.2.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b8afd55bde24d9ddd3cc352b2fa4ffe7b17b0b5f  analysed-packages/alsa-lib/version-1.2.8/alsa-lib-1.2.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/alsa-utils/version-1.2.8/alsa-utils-1.2.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/alsa-utils/version-1.2.8/alsa-utils-1.2.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+956ace5b0824178761f87f6ff5d3e36c38b5b8d2  analysed-packages/alsa-utils/version-1.2.8/alsa-utils-1.2.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/angular/version-15.1.0/angular-15.1.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/angular/version-15.1.0/angular-15.1.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+9bd2a1d4f1777eed3ea1eaf6bc5fd0a031677a0b  analysed-packages/angular/version-15.1.0/angular-15.1.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/angular/version-15.2.2/angular-15.2.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/angular/version-15.2.2/angular-15.2.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c5d658dfe6fd15cb78b8b78872e15759d182eed6  analysed-packages/angular/version-15.2.2/angular-15.2.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/angular/version-16.0.1/angular-16.0.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/angular/version-16.0.1/angular-16.0.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+10f14d8df6a3ba0f7ceba78a621a850a6e1013c2  analysed-packages/angular/version-16.0.1/angular-16.0.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/angular/version-16.1.2/angular-16.1.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/angular/version-16.1.2/angular-16.1.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+9fc3fdb4a32c299233d5994dfe8652df90856453  analysed-packages/angular/version-16.1.2/angular-16.1.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/apt/version-2.6.0/apt-2.6.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/apt/version-2.6.0/apt-2.6.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2978b7891b01b8a2ca27ba4e053dffc5a15f1a8c  analysed-packages/apt/version-2.6.0/apt-2.6.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/attr/version-2.4.48/attr-2.4.48-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/attr/version-2.4.48/attr-2.4.48-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+45053747a11525afbd35a77b0879e25ae5db977b  analysed-packages/attr/version-2.4.48/attr-2.4.48-SPDX2TV.spdx

--- a/.verifications/analysed-packages/attr/version-2.5.1/attr-2.5.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/attr/version-2.5.1/attr-2.5.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+351336369b8ff5715df2c3ec144a46457e8ee5aa  analysed-packages/attr/version-2.5.1/attr-2.5.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/audit/version-3.0.8/audit-3.0.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/audit/version-3.0.8/audit-3.0.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+edf56bf05c6d9405597e085ac6bac50ddfd034b5  analysed-packages/audit/version-3.0.8/audit-3.0.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/barebox/version-2023.05.0/barebox-2023.05.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/barebox/version-2023.05.0/barebox-2023.05.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f57740ec88ccd29c941da90f146bdcfca7c4a9a3  analysed-packages/barebox/version-2023.05.0/barebox-2023.05.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/base-passwd-debian/version-3.6.1/base-passwd-debian-3.6.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/base-passwd-debian/version-3.6.1/base-passwd-debian-3.6.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+616ec551fe44cd551a8b8b36bfe7d5b377956a43  analysed-packages/base-passwd-debian/version-3.6.1/base-passwd-debian-3.6.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bash/version-5.1.16/bash-5.1.16-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bash/version-5.1.16/bash-5.1.16-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4749508b0351879c10722f227953f7cf5b671da7  analysed-packages/bash/version-5.1.16/bash-5.1.16-SPDX2TV.spdx

--- a/.verifications/analysed-packages/behaviorTree.CPP/version-3.8.0/BehaviorTree.CPP-3.8.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/behaviorTree.CPP/version-3.8.0/BehaviorTree.CPP-3.8.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+5a2605a4521de9f43672603fb446156490ba0a8e  analysed-packages/behaviorTree.CPP/version-3.8.0/BehaviorTree.CPP-3.8.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bionic/version-cts-12.1_r2/platform_bionic-android-cts-12.1_r2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bionic/version-cts-12.1_r2/platform_bionic-android-cts-12.1_r2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3158729d3d65f8460f1f0b7915c115bb19a83dfa  analysed-packages/bionic/version-cts-12.1_r2/platform_bionic-android-cts-12.1_r2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/boost/version-1.81.0/boost-1.81.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/boost/version-1.81.0/boost-1.81.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f38c8f4ae310237876f2894dbb2d23456ab88a99  analysed-packages/boost/version-1.81.0/boost-1.81.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bootstrap/version-4.0.0/bootstrap-4.0.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bootstrap/version-4.0.0/bootstrap-4.0.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6d8df2da4d2a5340c7cf065f932adf9e49c294ec  analysed-packages/bootstrap/version-4.0.0/bootstrap-4.0.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bootstrap/version-5.1.3/bootstrap-5.1.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bootstrap/version-5.1.3/bootstrap-5.1.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+65bc57200ab8cfc85df12f7fb3fd80f2f134bc8d  analysed-packages/bootstrap/version-5.1.3/bootstrap-5.1.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bootstrap/version-5.2.3/bootstrap-5.2.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bootstrap/version-5.2.3/bootstrap-5.2.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+35af0b901393fdd6747997787a85d4b002748923  analysed-packages/bootstrap/version-5.2.3/bootstrap-5.2.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/brotli/version-1.0.9/brotli-1.0.9-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/brotli/version-1.0.9/brotli-1.0.9-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6ca05fb78335ba9b99121f1e209089f8d77e91d9  analysed-packages/brotli/version-1.0.9/brotli-1.0.9-SPDX2TV.spdx

--- a/.verifications/analysed-packages/busybox/version-1.35.0/busybox-1.35.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/busybox/version-1.35.0/busybox-1.35.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e6cda8ae17d6994a2395cfd5d9ca76fcdad50005  analysed-packages/busybox/version-1.35.0/busybox-1.35.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/busybox/version-1.36.1/busybox-1.36.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/busybox/version-1.36.1/busybox-1.36.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+934c868ccd356921eab975825dab298f6e67dec9  analysed-packages/busybox/version-1.36.1/busybox-1.36.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/bzip2/version-1.0.8/bzip2-1.0.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/bzip2/version-1.0.8/bzip2-1.0.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+dafa520336d4d3179491e75fb501df71a59bb756  analysed-packages/bzip2/version-1.0.8/bzip2-1.0.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/cdebconf/version-0.266/cdebconf-0.266-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/cdebconf/version-0.266/cdebconf-0.266-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f5076cb6145184364598b10126379473853ee926  analysed-packages/cdebconf/version-0.266/cdebconf-0.266-SPDX2TV.spdx

--- a/.verifications/analysed-packages/checkpolicy/version-3.4/checkpolicy-3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/checkpolicy/version-3.4/checkpolicy-3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1a2512d5a80638192b073fc3ee9474df6c552e0f  analysed-packages/checkpolicy/version-3.4/checkpolicy-3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/checkpolicy/version-3.5/checkpolicy-3.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/checkpolicy/version-3.5/checkpolicy-3.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3f7bc62ce45ecd3b00f86800e3cb61bddfa097df  analysed-packages/checkpolicy/version-3.5/checkpolicy-3.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/coreboot/version-4.16/coreboot-4.16-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/coreboot/version-4.16/coreboot-4.16-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+a21e136bd2ac101e65a8f9ce88b0140c25b213ee  analysed-packages/coreboot/version-4.16/coreboot-4.16-SPDX2TV.spdx

--- a/.verifications/analysed-packages/coreutils/version-9.1/coreutils-9.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/coreutils/version-9.1/coreutils-9.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+577268d15ffdcf8c8f7f813794d992a141b90d2d  analysed-packages/coreutils/version-9.1/coreutils-9.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/coreutils/version-9.3/coreutils-9.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/coreutils/version-9.3/coreutils-9.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1b473de46ae8ffd314c4a6c83a03950355e9b012  analysed-packages/coreutils/version-9.3/coreutils-9.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/cpio/version-2.13/cpio-2.13-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/cpio/version-2.13/cpio-2.13-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+25b3130c6738b28d112f925d1983788fedffc332  analysed-packages/cpio/version-2.13/cpio-2.13-SPDX2TV.spdx

--- a/.verifications/analysed-packages/cpio/version-2.14/cpio-2.14-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/cpio/version-2.14/cpio-2.14-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+88168ebda90125ac68b553438d5aa012b678eee7  analysed-packages/cpio/version-2.14/cpio-2.14-SPDX2TV.spdx

--- a/.verifications/analysed-packages/curl/version-7.86.0/curl-7.86.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/curl/version-7.86.0/curl-7.86.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+16f9888a8e21826609c2b5c7126add2a23dc987f  analysed-packages/curl/version-7.86.0/curl-7.86.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/curl/version-7.88.0/curl-7.88.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/curl/version-7.88.0/curl-7.88.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4d4ba784ffbeeaf7ad33b6cf818baf4ce482ccd5  analysed-packages/curl/version-7.88.0/curl-7.88.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/curl/version-8.0.1/curl-8.0.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/curl/version-8.0.1/curl-8.0.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+edc8927b36fcbaf43c1d91b725c9d0adba74ae0a  analysed-packages/curl/version-8.0.1/curl-8.0.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/curl/version-8.1.2/curl-8.1.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/curl/version-8.1.2/curl-8.1.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+72f8f2c084a461a79d1db2714a207a45d2ca6657  analysed-packages/curl/version-8.1.2/curl-8.1.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dart-lang/analyzer/version-2.8.0/analyzer-2.8.0.-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dart-lang/analyzer/version-2.8.0/analyzer-2.8.0.-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+8766027f9dc31169c932f395d7cc7cbe55c697d4  analysed-packages/dart-lang/analyzer/version-2.8.0/analyzer-2.8.0.-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dart-lang/args/version-2.3.0/args-2.3.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dart-lang/args/version-2.3.0/args-2.3.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+a9f52eda4864fb743cb714a4820cbfa3cefa8f68  analysed-packages/dart-lang/args/version-2.3.0/args-2.3.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dart-lang/characters/version-1.2.0/characters-1.2.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dart-lang/characters/version-1.2.0/characters-1.2.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ea34201ccc8bc2012696c3667e44b970228ba834  analysed-packages/dart-lang/characters/version-1.2.0/characters-1.2.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dart-lang/clock/version-1.1.0/clock-1.1.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dart-lang/clock/version-1.1.0/clock-1.1.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d014e66264e62bf810a22082d7060fa683c20726  analysed-packages/dart-lang/clock/version-1.1.0/clock-1.1.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dart-lang/html/version-0.15.0/html-0.15.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dart-lang/html/version-0.15.0/html-0.15.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+bd588fe7452eee5f84ad24e89cb7bbc7483e3b83  analysed-packages/dart-lang/html/version-0.15.0/html-0.15.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dash/version-0.5.11.4/dash-0.5.11.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dash/version-0.5.11.4/dash-0.5.11.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b6fdd4849ffcb22a7158ceb7bdef653775829dc8  analysed-packages/dash/version-0.5.11.4/dash-0.5.11.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dash/version-0.5.12/dash-0.5.12-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dash/version-0.5.12/dash-0.5.12-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+78bc45679cca595d0c5adca4a39677b47a9cc549  analysed-packages/dash/version-0.5.12/dash-0.5.12-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dbus/version-1.12.24/dbus-1.12.24-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dbus/version-1.12.24/dbus-1.12.24-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4684941c4085b9b58446a64f919e4aba1e725323  analysed-packages/dbus/version-1.12.24/dbus-1.12.24-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dbus/version-1.15.2/dbus-1.15.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dbus/version-1.15.2/dbus-1.15.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7f8a07b216a49d304521ff6e57487369fb9f314a  analysed-packages/dbus/version-1.15.2/dbus-1.15.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/debianutils/version-5.7-0.3/debianutils-5.7-0.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/debianutils/version-5.7-0.3/debianutils-5.7-0.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b4b3b88df451abf9d59a1f7b9952c4e842de7339  analysed-packages/debianutils/version-5.7-0.3/debianutils-5.7-0.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/diffutils/version-3.5/diffutils-3.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/diffutils/version-3.5/diffutils-3.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+13fe73d256fab25197688185ac2386cbcf238dcc  analysed-packages/diffutils/version-3.5/diffutils-3.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/dpkg/version-1.21.21/dpkg-1.21.21-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/dpkg/version-1.21.21/dpkg-1.21.21-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6c5bb28f473230aebd2ecb89e24eaba46afbb527  analysed-packages/dpkg/version-1.21.21/dpkg-1.21.21-SPDX2TV.spdx

--- a/.verifications/analysed-packages/efibootguard/version-0.11/efibootguard-0.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/efibootguard/version-0.11/efibootguard-0.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e0a16bf7c5124995c53f99d71bb0968ff586ac3e  analysed-packages/efibootguard/version-0.11/efibootguard-0.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ethtool/version-6.1/ethtool-6.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ethtool/version-6.1/ethtool-6.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0ec39aa4319ea22b68c5c4bbe3839bca601e034a  analysed-packages/ethtool/version-6.1/ethtool-6.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/expat/version-2.5.0/libexpat-2.5.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/expat/version-2.5.0/libexpat-2.5.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b5d3ae54f6d284d28fea205301fb422657a7e8d8  analysed-packages/expat/version-2.5.0/libexpat-2.5.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ffmpeg/version-n5.1.1/FFmpeg-n5.1.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ffmpeg/version-n5.1.1/FFmpeg-n5.1.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+48b2a0bfa74d22b8c536b302a2f8897157aa8d47  analysed-packages/ffmpeg/version-n5.1.1/FFmpeg-n5.1.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ffmpeg/version-n5.1.2/FFmpeg-n5.1.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ffmpeg/version-n5.1.2/FFmpeg-n5.1.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3c5055d7c26baa4519e373ba0b265b80b7c8a2d6  analysed-packages/ffmpeg/version-n5.1.2/FFmpeg-n5.1.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/file/version-5.44/file-FILE5_44-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/file/version-5.44/file-FILE5_44-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+aed5ee296a39909825cdf7e03068dcd69fa0e71d  analysed-packages/file/version-5.44/file-FILE5_44-SPDX2TV.spdx

--- a/.verifications/analysed-packages/findutils/version-4.8.0/findutils-4.8.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/findutils/version-4.8.0/findutils-4.8.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+69b9aa5e4e024ad98132d7cfef532acb8b892f0d  analysed-packages/findutils/version-4.8.0/findutils-4.8.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/flutter/version-3.3.8/flutter-3.3.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/flutter/version-3.3.8/flutter-3.3.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0d26931f9381ac1703f0d1daf778ea3fc3263ec3  analysed-packages/flutter/version-3.3.8/flutter-3.3.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/flutter/version-3.7.0/flutter-3.7.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/flutter/version-3.7.0/flutter-3.7.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f5e2935ebbac157f2ebaaf3ec2744b2f7dbca625  analysed-packages/flutter/version-3.7.0/flutter-3.7.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/freetype/version-VER-2-13-0/freetype-VER-2-13-0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/freetype/version-VER-2-13-0/freetype-VER-2-13-0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+57942a3b5cbad4c2f2e4a5a74cb6997064d21398  analysed-packages/freetype/version-VER-2-13-0/freetype-VER-2-13-0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/glib/version-2.75.2/glib-2.75.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/glib/version-2.75.2/glib-2.75.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6c2eeedde6f7617a6763787b9e10b0a7e5362c16  analysed-packages/glib/version-2.75.2/glib-2.75.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/glib/version-2.77.0/glib-2.77.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/glib/version-2.77.0/glib-2.77.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+02edc715e87bcdeecd04b793c68bec97157befd3  analysed-packages/glib/version-2.77.0/glib-2.77.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/glibc/version-2.36/glibc-2.36-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/glibc/version-2.36/glibc-2.36-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c5d6f8e58ace91b08f13d760fa0b85a65b7969a3  analysed-packages/glibc/version-2.36/glibc-2.36-SPDX2TV.spdx

--- a/.verifications/analysed-packages/glibc/version-2.37/glibc-2.37-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/glibc/version-2.37/glibc-2.37-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ef281454f4654791def18459cf0c6f2dc1265b35  analysed-packages/glibc/version-2.37/glibc-2.37-SPDX2TV.spdx

--- a/.verifications/analysed-packages/gmp/version-6.2.1/gmp-6.2.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/gmp/version-6.2.1/gmp-6.2.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ebc81682be310c20195c21927a078db3a76706d1  analysed-packages/gmp/version-6.2.1/gmp-6.2.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/gnutls/version-3.7.8/gnutls-3.7.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/gnutls/version-3.7.8/gnutls-3.7.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ba667ecd1995260b09b1311f0311b025fb3713b1  analysed-packages/gnutls/version-3.7.8/gnutls-3.7.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/grep/version-3.6/grep-3.6-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/grep/version-3.6/grep-3.6-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+77f6438f8f07a8aba6d207150eea2af750439db9  analysed-packages/grep/version-3.6/grep-3.6-SPDX2TV.spdx

--- a/.verifications/analysed-packages/grpc/version-1.52.1/grpc-1.52.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/grpc/version-1.52.1/grpc-1.52.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+a20abf0674083334ad814a65c4686797183e741a  analysed-packages/grpc/version-1.52.1/grpc-1.52.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/grub2/version-2.06/grub-2.06-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/grub2/version-2.06/grub-2.06-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+92d10de81474d801d7a8b7ceee0ff9e7925a7a42  analysed-packages/grub2/version-2.06/grub-2.06-SPDX2TV.spdx

--- a/.verifications/analysed-packages/gzip/version-1.12/gzip-1.12-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/gzip/version-1.12/gzip-1.12-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7d8b5e2f8fe74ae71e75338cf8de618b8331ca54  analysed-packages/gzip/version-1.12/gzip-1.12-SPDX2TV.spdx

--- a/.verifications/analysed-packages/hammerjs/version-2.0.8/hammer.js-2.0.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/hammerjs/version-2.0.8/hammer.js-2.0.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+672aec6a859e888456fbbfd2329e0c7121358e63  analysed-packages/hammerjs/version-2.0.8/hammer.js-2.0.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/hiawatha/version-11.2/hiawatha-11.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/hiawatha/version-11.2/hiawatha-11.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d82ae399daf701037882e1be1c35a4ebc40d6d4a  analysed-packages/hiawatha/version-11.2/hiawatha-11.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/htop/version-3.2.2/htop-3.2.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/htop/version-3.2.2/htop-3.2.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4fddb43943e55c58415c50eb51b22cf6e695b10d  analysed-packages/htop/version-3.2.2/htop-3.2.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/iceoryx/version-2.0.2/iceoryx-2.0.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/iceoryx/version-2.0.2/iceoryx-2.0.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4e85fa575ec5480917cfc51c73b3171f432a8060  analysed-packages/iceoryx/version-2.0.2/iceoryx-2.0.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/init-system-helpers-debian/version-1.65.2/init-system-helpers-debian-1.65.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/init-system-helpers-debian/version-1.65.2/init-system-helpers-debian-1.65.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+9592087dbd6e9328a8c58d457ba19cbc15f58744  analysed-packages/init-system-helpers-debian/version-1.65.2/init-system-helpers-debian-1.65.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/initramfs-tools/version-0.142/initramfs-tools-v0.142-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/initramfs-tools/version-0.142/initramfs-tools-v0.142-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+120c1c377a238752d806c350b3a9997d810dfd74  analysed-packages/initramfs-tools/version-0.142/initramfs-tools-v0.142-SPDX2TV.spdx

--- a/.verifications/analysed-packages/jpeg/version-v9e/jpegsrc.v9e-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/jpeg/version-v9e/jpegsrc.v9e-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2afd6fc7338e96e537901824b33da953ad0f5b6a  analysed-packages/jpeg/version-v9e/jpegsrc.v9e-SPDX2TV.spdx

--- a/.verifications/analysed-packages/jquery/version-1.9.1/jquery-1.9.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/jquery/version-1.9.1/jquery-1.9.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+51fd25a3ed90bbca0c1da276026dd40cd935ca9a  analysed-packages/jquery/version-1.9.1/jquery-1.9.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/json/version-3.11.2/json-3.11.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/json/version-3.11.2/json-3.11.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+103a09687485c499b0d13f72cef5bb9ea7ae7b2e  analysed-packages/json/version-3.11.2/json-3.11.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/kbd/version-2.5.1/kbd-2.5.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/kbd/version-2.5.1/kbd-2.5.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3a705087e7c9da0808a844928098544c138cc570  analysed-packages/kbd/version-2.5.1/kbd-2.5.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/keyutils/version-1.6.1/keyutils-1.6.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/keyutils/version-1.6.1/keyutils-1.6.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+66c331985db891ea6a284da4b4a89d85328bc66d  analysed-packages/keyutils/version-1.6.1/keyutils-1.6.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/klibc/version-2.0.11/klibc-2.0.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/klibc/version-2.0.11/klibc-2.0.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+753758ff293368046b158f8c32452e4fb16d919e  analysed-packages/klibc/version-2.0.11/klibc-2.0.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/klibc/version-2.0.12/klibc-2.0.12-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/klibc/version-2.0.12/klibc-2.0.12-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b618f6937bb73ec3b8921c350d5311e1284241ab  analysed-packages/klibc/version-2.0.12/klibc-2.0.12-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libbsd/version-0.11.7/libbsd-0.11.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libbsd/version-0.11.7/libbsd-0.11.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+cd40d8f211dcb11cef330ef8fb642d41367ddd99  analysed-packages/libbsd/version-0.11.7/libbsd-0.11.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libcap-ng/version-0.8.3/libcap-ng-0.8.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libcap-ng/version-0.8.3/libcap-ng-0.8.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3e466012f497f514e09f26ed04244fac701ad2fd  analysed-packages/libcap-ng/version-0.8.3/libcap-ng-0.8.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libffi/version-3.4.0/libffi-3.4.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libffi/version-3.4.0/libffi-3.4.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+11d2d6fce097bba28d0759559778f62b77023e64  analysed-packages/libffi/version-3.4.0/libffi-3.4.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libgpg-error/version-1.46/libgpg-error-1.46-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libgpg-error/version-1.46/libgpg-error-1.46-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+817c591f7707dee7020f07d42e9c1e864c1d573a  analysed-packages/libgpg-error/version-1.46/libgpg-error-1.46-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libmicrohttpd/version-0.9.75/libmicrohttpd-0.9.75-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libmicrohttpd/version-0.9.75/libmicrohttpd-0.9.75-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+46e3b99298bcfd307ee8276e92806174b7587643  analysed-packages/libmicrohttpd/version-0.9.75/libmicrohttpd-0.9.75-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libnsl/version-2.0.0/libnsl-2.0.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libnsl/version-2.0.0/libnsl-2.0.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+41886e552623361d766f3a8aa13b1a9cefca0012  analysed-packages/libnsl/version-2.0.0/libnsl-2.0.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libpng/version-1.6.38/libpng-1.6.38-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libpng/version-1.6.38/libpng-1.6.38-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b8413b1fa447b9a9c64c145c4c100ca20881c600  analysed-packages/libpng/version-1.6.38/libpng-1.6.38-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libseccomp/version-2.5.1/libseccomp-2.5.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libseccomp/version-2.5.1/libseccomp-2.5.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+696b6ed47dd667215acedf1bfab9b2ec53d79819  analysed-packages/libseccomp/version-2.5.1/libseccomp-2.5.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libselinux/version-3.4/libselinux-3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libselinux/version-3.4/libselinux-3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0effc98ff9e0162ea3cf4ced3e8c397229fc6d6d  analysed-packages/libselinux/version-3.4/libselinux-3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libselinux/version-3.5/selinux-3.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libselinux/version-3.5/selinux-3.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0ddf2a12da875de9f7835cba4f69b943dd25f3a3  analysed-packages/libselinux/version-3.5/selinux-3.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libsemanage/version-3.4/libsemanage-3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libsemanage/version-3.4/libsemanage-3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0e27571f77fa171b7fd0b82acd04f7747f655ec7  analysed-packages/libsemanage/version-3.4/libsemanage-3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libsemanage/version-3.5/libsemanage-3.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libsemanage/version-3.5/libsemanage-3.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+8fd060d382386a9d84991d1b99ec5cb6ea541233  analysed-packages/libsemanage/version-3.5/libsemanage-3.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libsepol/version-3.4/libsepol-3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libsepol/version-3.4/libsepol-3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+827caf808e643c927d368abf7012146f36b0d48b  analysed-packages/libsepol/version-3.4/libsepol-3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libsepol/version-3.5/libsepol-3.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libsepol/version-3.5/libsepol-3.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+49fa10e85b0610633c9a68f4041a2afeab2c3fef  analysed-packages/libsepol/version-3.5/libsepol-3.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libtasn1/version-4.19.0/libtasn1-4.19.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libtasn1/version-4.19.0/libtasn1-4.19.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+afd63923d795eec9b982406e5982217e7f75153f  analysed-packages/libtasn1/version-4.19.0/libtasn1-4.19.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libtiff/version-4.5.0/libtiff-v4.5.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libtiff/version-4.5.0/libtiff-v4.5.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3514ad5b8f7c3374ad704558391c333344fef3dd  analysed-packages/libtiff/version-4.5.0/libtiff-v4.5.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libtirpc/version-1.3.2/libtirpc-1.3.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libtirpc/version-1.3.2/libtirpc-1.3.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+cd5ba0ee84bb34ddea6a4c95fa16fbefc34a17dc  analysed-packages/libtirpc/version-1.3.2/libtirpc-1.3.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libusb/version-1.0.26/libusb-1.0.26-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libusb/version-1.0.26/libusb-1.0.26-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+62d91a38a5b4494e0e026dca7363e447993a87e9  analysed-packages/libusb/version-1.0.26/libusb-1.0.26-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libvirt/version-9.4.0/libvirt-9.4.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libvirt/version-9.4.0/libvirt-9.4.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+71beaeb6d4e33e3d98b66020368e86a8168e7593  analysed-packages/libvirt/version-9.4.0/libvirt-9.4.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/libvirt/version-9.5.0/libvirt-9.5.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/libvirt/version-9.5.0/libvirt-9.5.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+fe17d4e7be03472b8cc410f258045b5e29ecd67f  analysed-packages/libvirt/version-9.5.0/libvirt-9.5.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/lighthttpd/version-1.4.67/lighttpd-1.4.67-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/lighthttpd/version-1.4.67/lighttpd-1.4.67-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4de019cc321a513c1ed6fa6ed6166d0da11c3a0a  analysed-packages/lighthttpd/version-1.4.67/lighttpd-1.4.67-SPDX2TV.spdx

--- a/.verifications/analysed-packages/lighthttpd/version-1.4.69/lighttpd-1.4.69-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/lighthttpd/version-1.4.69/lighttpd-1.4.69-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+036259be2f0b9603152f6ae0edcbb13117263790  analysed-packages/lighthttpd/version-1.4.69/lighttpd-1.4.69-SPDX2TV.spdx

--- a/.verifications/analysed-packages/linux/version-6.0/linux-6.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/linux/version-6.0/linux-6.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+92b344f4b01c297f9a92d5d812edb972f0a2934c  analysed-packages/linux/version-6.0/linux-6.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/luos_engine/version-2.8.0/luos_engine-2.8.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/luos_engine/version-2.8.0/luos_engine-2.8.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+569085cd1927d62169d3d246354519417d89493e  analysed-packages/luos_engine/version-2.8.0/luos_engine-2.8.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/lvgl/version-8.3.3/lvgl-8.3.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/lvgl/version-8.3.3/lvgl-8.3.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7c48b7a22a75f7f94f801011eb66f211e0da5fcb  analysed-packages/lvgl/version-8.3.3/lvgl-8.3.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/lz4/version-1.9.4/lz4-1.9.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/lz4/version-1.9.4/lz4-1.9.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e96f24fea0bc78a55985a533da0075889b61fd7b  analysed-packages/lz4/version-1.9.4/lz4-1.9.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/mawk/version-1.3.4/mawk-1.3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/mawk/version-1.3.4/mawk-1.3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d9ea1dcefdf48b8046cd2c7bbb9503f1831227d1  analysed-packages/mawk/version-1.3.4/mawk-1.3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/mbedtls/version-3.0.0/mbedtls-3.0.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/mbedtls/version-3.0.0/mbedtls-3.0.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2a87b1366c4a4961c10a571f245cbe4b16c4b655  analysed-packages/mbedtls/version-3.0.0/mbedtls-3.0.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/mbedtls/version-3.2.1/mbedtls-3.2.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/mbedtls/version-3.2.1/mbedtls-3.2.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+cd04384b4b3c2eea4834e5ff0b276d30d05a9f79  analysed-packages/mbedtls/version-3.2.1/mbedtls-3.2.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/mbedtls/version-3.4.0/mbedtls-3.4.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/mbedtls/version-3.4.0/mbedtls-3.4.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+af3696d2ee77714843424a6a1bddf70906758790  analysed-packages/mbedtls/version-3.4.0/mbedtls-3.4.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/musl/version-1.2.2/musl-1.2.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/musl/version-1.2.2/musl-1.2.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+94bc75f782b2227ccc50b066143ce8d6cf6a41f6  analysed-packages/musl/version-1.2.2/musl-1.2.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/musl/version-1.2.3/musl-1.2.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/musl/version-1.2.3/musl-1.2.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+09342ff5bc07783824554cd02a3df1f5bb99285a  analysed-packages/musl/version-1.2.3/musl-1.2.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/musl/version-1.2.4/musl-1.2.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/musl/version-1.2.4/musl-1.2.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f0a563a9e522934e5880cd0530a0ad4db61e7126  analysed-packages/musl/version-1.2.4/musl-1.2.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nano/version-7.1/nano-7.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nano/version-7.1/nano-7.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+cad7ba8a87ab4b9df4db4215f309857c02350fb1  analysed-packages/nano/version-7.1/nano-7.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nanoflann/version-1.4.3/nanoflann-1.4.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nanoflann/version-1.4.3/nanoflann-1.4.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e82968382e453fe385e640c705fa350c4e438efd  analysed-packages/nanoflann/version-1.4.3/nanoflann-1.4.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/navigation2/version-1.1.3/navigation2-1.1.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/navigation2/version-1.1.3/navigation2-1.1.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3c2c8ccdd4a54632b5c25653baedceb143df1b5c  analysed-packages/navigation2/version-1.1.3/navigation2-1.1.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ncurses/version-6.4/ncurses-6.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ncurses/version-6.4/ncurses-6.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+bb14c50a18a52c208dbab9595eb57ca0b127eb91  analysed-packages/ncurses/version-6.4/ncurses-6.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nettle/version-3.8/nettle-3.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nettle/version-3.8/nettle-3.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+9e1899d65936f9ed365f410366245aa09cf5c87a  analysed-packages/nettle/version-3.8/nettle-3.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nghttp2/version-1.50.0/nghttp2-1.50.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nghttp2/version-1.50.0/nghttp2-1.50.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+57b357cdf6be6f6d1c5cc6c42ef71374bdeafbaf  analysed-packages/nghttp2/version-1.50.0/nghttp2-1.50.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nghttp2/version-1.51.0/nghttp2-1.51.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nghttp2/version-1.51.0/nghttp2-1.51.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+fff379989a2a66dce2488ab2f4e1753964178870  analysed-packages/nghttp2/version-1.51.0/nghttp2-1.51.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nghttp2/version-1.52.0/nghttp2-1.52.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nghttp2/version-1.52.0/nghttp2-1.52.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f62c5a4f029ec7cd2467413114d21c369e5d1c4c  analysed-packages/nghttp2/version-1.52.0/nghttp2-1.52.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nginx/version-1.20.2/nginx-1.20.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nginx/version-1.20.2/nginx-1.20.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+346dcfa2cd854aff994c525445d16ed360e338e4  analysed-packages/nginx/version-1.20.2/nginx-1.20.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nginx/version-1.23.3/nginx-1.23.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nginx/version-1.23.3/nginx-1.23.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+133341855e82497a1964151cd068b1c279eaa8b1  analysed-packages/nginx/version-1.23.3/nginx-1.23.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/nginx/version-1.24.0/nginx-1.24.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/nginx/version-1.24.0/nginx-1.24.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e6d57d2d947c864e8a657cde65a083f44f71f114  analysed-packages/nginx/version-1.24.0/nginx-1.24.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ngtcp2/version-0.11.0/ngtcp2-0.11.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ngtcp2/version-0.11.0/ngtcp2-0.11.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7a2c5a07381d493b96d73d5f990bc872e1e195a1  analysed-packages/ngtcp2/version-0.11.0/ngtcp2-0.11.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/openSSH/version-9.3p1/openssh-9.3p1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/openSSH/version-9.3p1/openssh-9.3p1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+705134cf485c8fcdcf606dc5ffce814811c411f9  analysed-packages/openSSH/version-9.3p1/openssh-9.3p1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/p11-kit/version-0.24.0/p11-kit-0.24.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/p11-kit/version-0.24.0/p11-kit-0.24.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4f2b8fd47652b5f3a26629582af3875296f2cb1c  analysed-packages/p11-kit/version-0.24.0/p11-kit-0.24.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/paho.mqtt.c/version-1.3.11/paho.mqtt.c-1.3.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/paho.mqtt.c/version-1.3.11/paho.mqtt.c-1.3.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1cfa18439eaf800a5e4cd7fcdd831648b23a8bc6  analysed-packages/paho.mqtt.c/version-1.3.11/paho.mqtt.c-1.3.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/pam/version-1.5.2/linux-pam-1.5.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/pam/version-1.5.2/linux-pam-1.5.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+da542ef4d0adc3544c9ce2c11796389692b2b115  analysed-packages/pam/version-1.5.2/linux-pam-1.5.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/pam/version-1.5.3/linux-pam-1.5.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/pam/version-1.5.3/linux-pam-1.5.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+69729b0ccae82b30787186542b2427cb870fc432  analysed-packages/pam/version-1.5.3/linux-pam-1.5.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/procps-ng/version-4.0.3/procps-v4.0.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/procps-ng/version-4.0.3/procps-v4.0.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e793a0da8eb102396dee125d9c6129ad9d2d9ca5  analysed-packages/procps-ng/version-4.0.3/procps-v4.0.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/protobuf/version-21.11/protobuf-21.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/protobuf/version-21.11/protobuf-21.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+35a8cb53bbeea2856940e7b7afa253a1195cc047  analysed-packages/protobuf/version-21.11/protobuf-21.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/rancher/version-2.7.0/rancher-2.7.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/rancher/version-2.7.0/rancher-2.7.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+a4a9aff36047d394b5d216d3179b4e133f9da6c7  analysed-packages/rancher/version-2.7.0/rancher-2.7.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/rancher/version-2.7.3/rancher-2.7.3-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/rancher/version-2.7.3/rancher-2.7.3-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d9eb54cf6bd3ab2402f5afbc0548a922c115d610  analysed-packages/rancher/version-2.7.3/rancher-2.7.3-SPDX2TV.spdx

--- a/.verifications/analysed-packages/rauc/version-1.8/rauc-1.8-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/rauc/version-1.8/rauc-1.8-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+ef29743a0d7b2cdb2889049a5416cc9751d1477a  analysed-packages/rauc/version-1.8/rauc-1.8-SPDX2TV.spdx

--- a/.verifications/analysed-packages/rauc/version-1.9/rauc-1.9-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/rauc/version-1.9/rauc-1.9-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+3fb642869238a5569f9451eae7d0e8dde66f7985  analysed-packages/rauc/version-1.9/rauc-1.9-SPDX2TV.spdx

--- a/.verifications/analysed-packages/react/version-18.2.0/react-18.2.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/react/version-18.2.0/react-18.2.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2d1960df0ab3b952071c9561d66530eb18f8eed9  analysed-packages/react/version-18.2.0/react-18.2.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/relic/version-0.6.0/relic-0.6.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/relic/version-0.6.0/relic-0.6.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c39b1526d97a2ef2cc2c1a9b53be7133fd290966  analysed-packages/relic/version-0.6.0/relic-0.6.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/robin-hood/version-3.11.5/robin-hood-3.11.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/robin-hood/version-3.11.5/robin-hood-3.11.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2b773ee61359aa11fd30c643629a6b8e87ad8ca1  analysed-packages/robin-hood/version-3.11.5/robin-hood-3.11.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/ruckig/version-0.8.4/ruckig-0.8.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/ruckig/version-0.8.4/ruckig-0.8.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+bdeb5eef783c53eb6c7c7763e43b0787113cb3b5  analysed-packages/ruckig/version-0.8.4/ruckig-0.8.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/seL4/version-12.1.0/seL4-12.1.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/seL4/version-12.1.0/seL4-12.1.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b9f8e04fa52d3153b94b06c0a6568725725ac6ff  analysed-packages/seL4/version-12.1.0/seL4-12.1.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/shadow/version-4.13/shadow-4.13-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/shadow/version-4.13/shadow-4.13-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0fb0284ba54e3e5b4cb2ed702029e420630e713d  analysed-packages/shadow/version-4.13/shadow-4.13-SPDX2TV.spdx

--- a/.verifications/analysed-packages/shim/version-15.7/shim-15.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/shim/version-15.7/shim-15.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+597e723f63bd75e26e7e1c6b8da0c7c3e4bb331a  analysed-packages/shim/version-15.7/shim-15.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/sqlite/version-3.39.4/sqlite-3.39.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/sqlite/version-3.39.4/sqlite-3.39.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0d978122bdbe14ff9b56693761dc841c0c8cd77b  analysed-packages/sqlite/version-3.39.4/sqlite-3.39.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/sqlite/version-3.42.0/sqlite-3.42.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/sqlite/version-3.42.0/sqlite-3.42.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+2417685fd5fa0fa8585e87b8e7b0646e3d028c5b  analysed-packages/sqlite/version-3.42.0/sqlite-3.42.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/strace/version-6.4/strace-6.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/strace/version-6.4/strace-6.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+206e736bba01a9acf4d97aeae77c0d0222e63ec3  analysed-packages/strace/version-6.4/strace-6.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/swupdate/version-2022.05/swupdate-2022.05-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/swupdate/version-2022.05/swupdate-2022.05-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+0e983b84a3b3b3c4cb3687151b222325f90e6874  analysed-packages/swupdate/version-2022.05/swupdate-2022.05-SPDX2TV.spdx

--- a/.verifications/analysed-packages/swupdate/version-2022.12/swupdate-2022.12-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/swupdate/version-2022.12/swupdate-2022.12-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+5f08ada7ffb4385b49e93ff69939521ac438271b  analysed-packages/swupdate/version-2022.12/swupdate-2022.12-SPDX2TV.spdx

--- a/.verifications/analysed-packages/swupdate/version-2023.05/swupdate-2023.05-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/swupdate/version-2023.05/swupdate-2023.05-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+4ef9fc9dbf56b3f284cb920560dab323114bbada  analysed-packages/swupdate/version-2023.05/swupdate-2023.05-SPDX2TV.spdx

--- a/.verifications/analysed-packages/systemd/version-v251/systemd-251-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/systemd/version-v251/systemd-251-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+b0597e809bf504e27bc06686cb22b7785c66d724  analysed-packages/systemd/version-v251/systemd-251-SPDX2TV.spdx

--- a/.verifications/analysed-packages/sysvinit-utils/3.04/sysvinit-3.04-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/sysvinit-utils/3.04/sysvinit-3.04-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+617b7436dba459eed2b342dd4654a7a26bf10350  analysed-packages/sysvinit-utils/3.04/sysvinit-3.04-SPDX2TV.spdx

--- a/.verifications/analysed-packages/sysvinit/version-3.04/sysvinit-3.04-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/sysvinit/version-3.04/sysvinit-3.04-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+57db9c1a527b5e47cadb537ca9dfc725492f6eee  analysed-packages/sysvinit/version-3.04/sysvinit-3.04-SPDX2TV.spdx

--- a/.verifications/analysed-packages/tar/version-1.34/tar-1.34-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/tar/version-1.34/tar-1.34-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+71425666a2aa443767f7518e13c74b3abec0430e  analysed-packages/tar/version-1.34/tar-1.34-SPDX2TV.spdx

--- a/.verifications/analysed-packages/toybox/version-0.8.7/toybox-0.8.7-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/toybox/version-0.8.7/toybox-0.8.7-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+cfd7f423fbb200d292054c391fd8d0a74e8c6fc9  analysed-packages/toybox/version-0.8.7/toybox-0.8.7-SPDX2TV.spdx

--- a/.verifications/analysed-packages/u-boot/version-2022.04/u-boot-v2022.04-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/u-boot/version-2022.04/u-boot-v2022.04-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+594a992441a18105d20b7b38bb10bdb71dad4d98  analysed-packages/u-boot/version-2022.04/u-boot-v2022.04-SPDX2TV.spdx

--- a/.verifications/analysed-packages/usbutils/version-v015/usbutils-015-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/usbutils/version-v015/usbutils-015-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+6a78b3a04ceff825a7ef1fad6ca9320b59f4a591  analysed-packages/usbutils/version-v015/usbutils-015-SPDX2TV.spdx

--- a/.verifications/analysed-packages/wget2/version-2.0.1/wget2-2.0.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/wget2/version-2.0.1/wget2-2.0.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+161ce62ac5a80ee5e58d278bf63ffd972d3631b9  analysed-packages/wget2/version-2.0.1/wget2-2.0.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/xxHash/version-0.8.0/xxHash-0.8.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/xxHash/version-0.8.0/xxHash-0.8.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c7dd7723a0092abfd9184b6ebc36f5baded08aa4  analysed-packages/xxHash/version-0.8.0/xxHash-0.8.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/xxHash/version-0.8.1/xxHash-0.8.1-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/xxHash/version-0.8.1/xxHash-0.8.1-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1f10fc240b5fafa0d508bbb49a0cccbccd24acb8  analysed-packages/xxHash/version-0.8.1/xxHash-0.8.1-SPDX2TV.spdx

--- a/.verifications/analysed-packages/xz-utils/version-5.2.5/xz-5.2.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/xz-utils/version-5.2.5/xz-5.2.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+d3f5f23c1dac96c02017d85c7914f4236cc8a29c  analysed-packages/xz-utils/version-5.2.5/xz-5.2.5-SPDX2TV.spdx

--- a/.verifications/analysed-packages/xz-utils/version-5.4.2/xz-5.4.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/xz-utils/version-5.4.2/xz-5.4.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7bdbab20aa5a7cf6267febceadcee9cfe3073261  analysed-packages/xz-utils/version-5.4.2/xz-5.4.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/yaml-cpp/version-0.7.0/yaml-0.7.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/yaml-cpp/version-0.7.0/yaml-0.7.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+19114501b4bf4a82a832e816cf68228931eb0f40  analysed-packages/yaml-cpp/version-0.7.0/yaml-0.7.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zephyr/version-2.7.2/zephyr-2.7.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zephyr/version-2.7.2/zephyr-2.7.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c9638c320ac6bcc6b9ecd88fd5ed69e499354d72  analysed-packages/zephyr/version-2.7.2/zephyr-2.7.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zephyr/version-3.2.0/zephyr-v3.2.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zephyr/version-3.2.0/zephyr-v3.2.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+7c437fc920b641f6d176c9769383bdce4e057c3e  analysed-packages/zephyr/version-3.2.0/zephyr-v3.2.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zephyr/version-3.3.0/zephyr-v3.3.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zephyr/version-3.3.0/zephyr-v3.3.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+aea3c7683c6b1c6dbd93692304eaaa64a1aec2f1  analysed-packages/zephyr/version-3.3.0/zephyr-v3.3.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zephyr/version-3.4.0/zephyr-v3.4.0-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zephyr/version-3.4.0/zephyr-v3.4.0-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+01ed793088c3c65f6fa066eaaf366b865ee2fa6d  analysed-packages/zephyr/version-3.4.0/zephyr-v3.4.0-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zeroMQ/libzmq/version-4.3.4/libzmq-4.3.4-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zeroMQ/libzmq/version-4.3.4/libzmq-4.3.4-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+1585a184a1cd38a1f4dc95b878df2aaed16b126e  analysed-packages/zeroMQ/libzmq/version-4.3.4/libzmq-4.3.4-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zlib/version-1.2.11/zlib-1.2.11-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zlib/version-1.2.11/zlib-1.2.11-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+c7da7a4e177ec315f9adeb1893e0cbc395637df3  analysed-packages/zlib/version-1.2.11/zlib-1.2.11-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+e5ee25ab318c978bd5c1a9b4bdbc8079a1765d55  analysed-packages/zlib/version-1.2.12/zlib-1.2.12-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zstd/version-1.4.10/zstd-1.4.10-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zstd/version-1.4.10/zstd-1.4.10-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+fa8ed0a2edc3392036b2a39364cc82b12a6d7867  analysed-packages/zstd/version-1.4.10/zstd-1.4.10-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zstd/version-1.5.2/zstd-1.5.2-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zstd/version-1.5.2/zstd-1.5.2-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+092599a9126e67f20efa4fb992f74867ca778643  analysed-packages/zstd/version-1.5.2/zstd-1.5.2-SPDX2TV.spdx

--- a/.verifications/analysed-packages/zstd/version-1.5.5/zstd-1.5.5-SPDX2TV.spdx.verified
+++ b/.verifications/analysed-packages/zstd/version-1.5.5/zstd-1.5.5-SPDX2TV.spdx.verified
@@ -1,0 +1,1 @@
+f04463d965d3d33d134a77a34af379b4f414bde3  analysed-packages/zstd/version-1.5.5/zstd-1.5.5-SPDX2TV.spdx


### PR DESCRIPTION
I started adding some caching of verification: if the file was verified previously, and the hash that is stored still matches, it is considered verified.

This should make CI on main pretty fast again.