### PR TITLE
Fix Concluded License for bash-5.2.15/builtins/break.def in SPDX files

### DIFF
--- a/analysed-packages/bash/version-5.2.15/bash-5.2.15-SPDX2TV.spdx
+++ b/analysed-packages/bash/version-5.2.15/bash-5.2.15-SPDX2TV.spdx
@@ -34085,7 +34085,7 @@ SPDXID: SPDXRef-item3259927
 FileChecksum: SHA1: 7d0cb9c69bc8b13cd43ae2035ab8e811c5b97d18
 FileChecksum: SHA256: 4077768535be5cff07e749ebaba92913813c13be4dfbd65c7ff2baaba81d2a28
 FileChecksum: MD5: ef48f87f87376a7041648ed626875b27
-LicenseConcluded: NOASSERTION
+LicenseConcluded: LicenseRef-GPL-3.0-or-later
 LicenseInfoInFile: LicenseRef-GPL-3.0-or-later
 FileCopyrightText: <text> Copyright (C) 1987-2020 Free Software Foundation, Inc. </text>
  

--- a/analysed-packages/bash/version-5.2.15/bash-5.2.15.spdx.json
+++ b/analysed-packages/bash/version-5.2.15/bash-5.2.15.spdx.json
@@ -33449,7 +33449,7 @@
     } ],
     "copyrightText" : "Copyright (C) 1987-2020 Free Software Foundation, Inc.",
     "fileName" : "bash-5.2.15.tar.gz/bash-5.2.15.tar/bash-5.2.15/builtins/break.def",
-    "licenseConcluded" : "NOASSERTION",
+    "licenseConcluded" : "LicenseRef-GPL-3.0-or-later",
     "licenseInfoInFiles" : [ "LicenseRef-GPL-3.0-or-later" ]
   }, {
     "SPDXID" : "SPDXRef-item3259924",

--- a/analysed-packages/bash/version-5.2.15/bash-5.2.15.spdx.yaml
+++ b/analysed-packages/bash/version-5.2.15/bash-5.2.15.spdx.yaml
@@ -34570,7 +34570,7 @@ files:
     checksumValue: "ef48f87f87376a7041648ed626875b27"
   copyrightText: "Copyright (C) 1987-2020 Free Software Foundation, Inc."
   fileName: "bash-5.2.15.tar.gz/bash-5.2.15.tar/bash-5.2.15/builtins/break.def"
-  licenseConcluded: "NOASSERTION"
+  licenseConcluded: "LicenseRef-GPL-3.0-or-later"
   licenseInfoInFiles:
   - "LicenseRef-GPL-3.0-or-later"
 - SPDXID: "SPDXRef-item3259924"


### PR DESCRIPTION
Signed-off-by: Caren Kresse (ckresse@osadl.org)