### PR TITLE
fix selinux checkpolicy purl, according to purl specifications

### DIFF
--- a/analysed-packages/checkpolicy/version-3.4/README.md
+++ b/analysed-packages/checkpolicy/version-3.4/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.4.tar.
 
 ## Package URL (purl)
 
-pkg:github/SELinuxProject/checkpolicy@3.4
+pkg:github/selinuxproject/selinux@checkpolicy-3.4
 
 ## Creator
 

--- a/analysed-packages/checkpolicy/version-3.5/README.md
+++ b/analysed-packages/checkpolicy/version-3.5/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.5.tar.
 
 ## Package URL (purl)
 
-pkg:github/SELinuxProject/selinux/checkpolicy@3.5
+pkg:github/selinuxproject/selinux@checkpolicy-3.5
 
 ## Creator
 

--- a/analysed-packages/checkpolicy/version-3.6/README.md
+++ b/analysed-packages/checkpolicy/version-3.6/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.6.tar.
 
 ## Package URL (purl)
 
-pkg:github/SELinuxProject/selinux/checkpolicy@3.6
+pkg:github/selinuxproject/selinux@checkpolicy-3.6
 
 ## Creator
 

--- a/analysed-packages/checkpolicy/version-3.7/README.md
+++ b/analysed-packages/checkpolicy/version-3.7/README.md
@@ -4,7 +4,7 @@ https://github.com/SELinuxProject/selinux/archive/refs/tags/checkpolicy-3.7.tar.
 
 ## Package URL (purl)
 
-pkg:github/SELinuxProject/selinux/checkpolicy@3.7
+pkg:github/selinuxproject/selinux@checkpolicy-3.7
 
 ## Creator
 


### PR DESCRIPTION
According to the [PURL specifications](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#github), the github purls format is pkg:github/vendor/repo@tag, with vendor and repo name lowercased. So I think that for checkpolicy, the purl should either be, for example for version 3.4, "pkg:github/selinuxproject/selinux@checkpolicy-3.4", pointing to the checkpolicy-3.4 tag, or it could look like "pkg:github/selinuxproject/selinux@3.4#checkpolicy", pointing to the complete 3.4 tag, but only referencing the "checkpolicy" subpath inside it.