### PR TITLE
Corrected download location in the README of libconfig-v1.7.3

### DIFF
--- a/analysed-packages/libconfig/version-v1.7.3/README.md
+++ b/analysed-packages/libconfig/version-v1.7.3/README.md
@@ -1,6 +1,6 @@
 ## Download Location
 
-https://github.com/hyperrealm/libconfig/releases/tag/v1.7.3
+https://github.com/hyperrealm/libconfig/releases/download/v1.7.3/libconfig-1.7.3.tar.gz
 
 ## Package URL (purl)
 


### PR DESCRIPTION
The download location led to the HTML release page and not to the archive, corrected.