### PR TITLE
Repaired broken license identifiers and names

### DIFF
--- a/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1-SPDX2TV.spdx
+++ b/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1-SPDX2TV.spdx
@@ -252,7 +252,7 @@ SPDXID: SPDXRef-item148325683
 FileChecksum: SHA1: 58f42639012433ffd70bd45fd3ca24a2e6b2fbd2
 FileChecksum: SHA256: 459458e7fde6d3cbc7856e5d68c521c24d6b9cbdd11ebd48365ed0f28ed5dcbe
 FileChecksum: MD5: 53e0af956c50c08b3f10c4613eb4966c
-LicenseConcluded: LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa
+LicenseConcluded: LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa
 LicenseComments: <text>NOASSERTION </text>
 LicenseInfoInFile: LicenseRef-Freeware
 FileCopyrightText: <text> Copyright (c) 2002 by David I. Bell  </text>
@@ -265,7 +265,7 @@ SPDXID: SPDXRef-item148325073
 FileChecksum: SHA1: ae8b5bec70738c91d8b9d48fcb6f69494ea6f297
 FileChecksum: SHA256: 04dd8f3e45984bc746f21b286ee118afe2bce16b40b737892659f18f2d844b23
 FileChecksum: MD5: 55ddf626d4509512e0fb045b302d2b85
-LicenseConcluded: LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa AND LicenseRef-GPL-2.0-or-later
+LicenseConcluded: LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa AND LicenseRef-GPL-2.0-or-later
 LicenseComments: <text>NOASSERTION AND NOASSERTION </text>
 LicenseInfoInFile: LicenseRef-GPL-2.0-or-later
 FileCopyrightText: <text> Copyright (C) 1999-2004 by Erik Andersen <andersen@codepoet.org>
@@ -2665,7 +2665,7 @@ SPDXID: SPDXRef-item148325922
 FileChecksum: SHA1: 0e89595b8bf1ea3dc0482ccd5ef5ab77cd0456de
 FileChecksum: SHA256: 4bb46a66971f864c4e7ebb05e0e1070aa927b3d856f6a026ba7c23cffe4a3208
 FileChecksum: MD5: 6611f8a5515c749accfb511d3a32680c
-LicenseConcluded: LicenseRef--69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only
+LicenseConcluded: LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only
 LicenseComments: <text>NOASSERTION AND NOASSERTION </text>
 LicenseInfoInFile: LicenseRef-GPL-2.0-only
 LicenseInfoInFile: LicenseRef-X11-style
@@ -36679,8 +36679,8 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </text>
 
-LicenseID: LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa
-LicenseName: -b79dfa8d57b6aef14cf0aa1e0a5519fa
+LicenseID: LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa
+LicenseName: Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa
 ExtractedText: <text> Permission is granted to use, distribute, or modify this source,
 provided that this copyright notice remains intact. </text>
 
@@ -36896,8 +36896,8 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </text>
 
-LicenseID: LicenseRef--69056019a7e11459c6ebbd30becd17b0
-LicenseName: -69056019a7e11459c6ebbd30becd17b0
+LicenseID: LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0
+LicenseName: Permission-Notice-69056019a7e11459c6ebbd30becd17b0
 ExtractedText: <text> Permission to use, copy, modify, and distribute this software
 for any purpose and without fee is hereby granted. The author
 disclaims all warranties with regard to this software. </text>

--- a/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1.spdx.json
+++ b/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1.spdx.json
@@ -10,11 +10,11 @@
   "name" : "/srv/fossology/repository/report",
   "dataLicense" : "CC0-1.0",
   "hasExtractedLicensingInfos" : [ {
-    "licenseId" : "LicenseRef--69056019a7e11459c6ebbd30becd17b0",
+    "licenseId" : "LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0",
     "extractedText" : "Permission to use, copy, modify, and distribute this software\nfor any purpose and without fee is hereby granted. The author\ndisclaims all warranties with regard to this software.",
     "name" : "-69056019a7e11459c6ebbd30becd17b0"
   }, {
-    "licenseId" : "LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa",
+    "licenseId" : "LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa",
     "extractedText" : "Permission is granted to use, distribute, or modify this source,\nprovided that this copyright notice remains intact.",
     "name" : "-b79dfa8d57b6aef14cf0aa1e0a5519fa"
   }, {
@@ -16777,7 +16777,7 @@
     "copyrightText" : "Copyright (C) 1999-2004 by Erik Andersen <andersen@codepoet.org>\nCopyright (c) 1999 by David I. \nCopyright (C) 1995 Bruce Perens",
     "fileName" : "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/archival/tar.c",
     "licenseComments" : "NOASSERTION AND NOASSERTION",
-    "licenseConcluded" : "(LicenseRef-GPL-2.0-or-later AND LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa)",
+    "licenseConcluded" : "(LicenseRef-GPL-2.0-or-later AND LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa)",
     "licenseInfoInFiles" : [ "LicenseRef-GPL-2.0-or-later" ]
   }, {
     "SPDXID" : "SPDXRef-item148325070",
@@ -21363,7 +21363,7 @@
     "copyrightText" : "Copyright (C) 2009 Denys Vlasenko",
     "fileName" : "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/libbb/unicode.c",
     "licenseComments" : "NOASSERTION AND NOASSERTION",
-    "licenseConcluded" : "(LicenseRef--69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only)",
+    "licenseConcluded" : "(LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only)",
     "licenseInfoInFiles" : [ "LicenseRef-GPL-2.0-only", "LicenseRef-X11-style" ]
   }, {
     "SPDXID" : "SPDXRef-item148325923",
@@ -34093,7 +34093,7 @@
     "copyrightText" : "Copyright (c) 2002 by David I. Bell",
     "fileName" : "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/editors/ed.c",
     "licenseComments" : "NOASSERTION",
-    "licenseConcluded" : "LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa",
+    "licenseConcluded" : "LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa",
     "licenseInfoInFiles" : [ "LicenseRef-Freeware" ]
   }, {
     "SPDXID" : "SPDXRef-item148324352",

--- a/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1.spdx.yaml
+++ b/analysed-packages/Alpine/version-3.15/busybox-1.34.1/busybox-1.34.1.spdx.yaml
@@ -13,12 +13,12 @@ creationInfo:
 name: "/srv/fossology/repository/report"
 dataLicense: "CC0-1.0"
 hasExtractedLicensingInfos:
-- licenseId: "LicenseRef--69056019a7e11459c6ebbd30becd17b0"
+- licenseId: "LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0"
   extractedText: "Permission to use, copy, modify, and distribute this software\n\
     for any purpose and without fee is hereby granted. The author\ndisclaims all warranties\
     \ with regard to this software."
   name: "-69056019a7e11459c6ebbd30becd17b0"
-- licenseId: "LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa"
+- licenseId: "LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa"
   extractedText: "Permission is granted to use, distribute, or modify this source,\n\
     provided that this copyright notice remains intact."
   name: "-b79dfa8d57b6aef14cf0aa1e0a5519fa"
@@ -16098,7 +16098,7 @@ files:
     Copyright (c) 1999 by David I. \nCopyright (C) 1995 Bruce Perens"
   fileName: "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/archival/tar.c"
   licenseComments: "NOASSERTION AND NOASSERTION"
-  licenseConcluded: "(LicenseRef-GPL-2.0-or-later AND LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa)"
+  licenseConcluded: "(LicenseRef-GPL-2.0-or-later AND LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa)"
   licenseInfoInFiles:
   - "LicenseRef-GPL-2.0-or-later"
 - SPDXID: "SPDXRef-item148325070"
@@ -19943,7 +19943,7 @@ files:
   copyrightText: "Copyright (C) 2009 Denys Vlasenko"
   fileName: "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/libbb/unicode.c"
   licenseComments: "NOASSERTION AND NOASSERTION"
-  licenseConcluded: "(LicenseRef--69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only)"
+  licenseConcluded: "(LicenseRef-Permission-Notice-69056019a7e11459c6ebbd30becd17b0 AND LicenseRef-GPL-2.0-only)"
   licenseInfoInFiles:
   - "LicenseRef-GPL-2.0-only"
   - "LicenseRef-X11-style"
@@ -30503,7 +30503,7 @@ files:
   copyrightText: "Copyright (c) 2002 by David I. Bell"
   fileName: "busybox-for-FOSSY.zip/busybox/src/busybox-1.34.1.tar.bz2/busybox-1.34.1.tar/busybox-1.34.1/editors/ed.c"
   licenseComments: "NOASSERTION"
-  licenseConcluded: "LicenseRef--b79dfa8d57b6aef14cf0aa1e0a5519fa"
+  licenseConcluded: "LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa"
   licenseInfoInFiles:
   - "LicenseRef-Freeware"
 - SPDXID: "SPDXRef-item148324352"


### PR DESCRIPTION
For some reason, the name of the primary license was omitted in several license identifiers and names, resulting in the invalid name component “--”. When retracing the curation using the source code files, it turned out that the name of the primary license is “Permission-Notice”, and the incorrect entries were repaired accordingly.